### PR TITLE
Fix #43: Crypto 3.0: New activation

### DIFF
--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/logging/JsonStepLogger.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/logging/JsonStepLogger.java
@@ -121,7 +121,7 @@ public class JsonStepLogger implements StepLogger {
         map.put("requestObject", requestObject);
         map.put("requestHeaders", headers);
         String name = "Sending Request";
-        String desc = "Calling PowerAuth 2.0 Standard RESTful API endpoint";
+        String desc = "Calling PowerAuth Standard RESTful API endpoint";
         String status = "OK";
         writeItem(name, desc, status, map);
     }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/CreateTokenStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/CreateTokenStep.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.getlime.security.powerauth.lib.cmd.steps;
+package io.getlime.security.powerauth.lib.cmd.steps.v2;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,28 +26,25 @@ import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.crypto.client.signature.PowerAuthClientSignature;
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEncryptor;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesFactory;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesCryptogram;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesSharedInfo1;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
-import io.getlime.security.powerauth.http.PowerAuthEncryptionHttpHeader;
 import io.getlime.security.powerauth.http.PowerAuthHttpBody;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.lib.cmd.logging.JsonStepLogger;
+import io.getlime.security.powerauth.lib.cmd.steps.BaseStep;
 import io.getlime.security.powerauth.lib.cmd.steps.model.CreateTokenStepModel;
 import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
 import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
 import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.rest.api.model.entity.TokenResponsePayload;
-import io.getlime.security.powerauth.rest.api.model.request.v3.TokenCreateRequest;
-import io.getlime.security.powerauth.rest.api.model.response.v3.TokenCreateResponse;
+import io.getlime.security.powerauth.rest.api.model.request.v2.TokenCreateRequest;
+import io.getlime.security.powerauth.rest.api.model.response.v2.TokenCreateResponse;
 import org.json.simple.JSONObject;
 
 import javax.crypto.SecretKey;
 import java.io.Console;
 import java.io.FileWriter;
-import java.nio.charset.StandardCharsets;
 import java.security.interfaces.ECPublicKey;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -55,6 +52,12 @@ import java.util.Map;
 
 /**
  * Helper class with token creation logic.
+ *
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *     <li>2.0</li>
+ *     <li>2.1</li>
+ * </ul>
  *
  * @author Petr Dvorak, petr@lime-company.eu
  */
@@ -64,7 +67,6 @@ public class CreateTokenStep implements BaseStep {
     private static final KeyGenerator keyGenerator = new KeyGenerator();
     private static final PowerAuthClientSignature signature = new PowerAuthClientSignature();
     private static final ObjectMapper mapper = new ObjectMapper();
-    private static final EciesFactory eciesFactory = new EciesFactory();
 
     /**
      * Execute this step with given context
@@ -112,50 +114,15 @@ public class CreateTokenStep implements BaseStep {
         // Generate nonce
         byte[] pa_nonce = keyGenerator.generateRandomBytes(16);
 
-        final EciesCryptogram eciesCryptogram;
-        final EciesEncryptor encryptor;
-        final String uri;
-        final ObjectRequest request;
+        final String uri = model.getUriString() + "/pa/token/create";
 
-        switch (model.getVersion()) {
-            case "3.0": {
-                uri = model.getUriString() + "/pa/v3/token/create";
-                final byte[] applicationSecret = BaseEncoding.base64().decode(model.getApplicationSecret());
-                byte[] transportMasterKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("transportMasterKey"));
-                byte[] serverPublicKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("serverPublicKey"));
-                ECPublicKey serverPublicKey = (ECPublicKey) keyConversion.convertBytesToPublicKey(serverPublicKeyBytes);
-                encryptor = eciesFactory.getEciesEncryptorForActivation(serverPublicKey, applicationSecret,
-                        transportMasterKeyBytes, EciesSharedInfo1.CREATE_TOKEN);
-                eciesCryptogram = encryptor.encryptRequest("{}".getBytes(StandardCharsets.UTF_8));
-
-                // Prepare encryption request
-                TokenCreateRequest requestObject = new TokenCreateRequest();
-                String ephemeralPublicKeyBase64 = BaseEncoding.base64().encode(eciesCryptogram.getEphemeralPublicKey());
-                String encryptedData = BaseEncoding.base64().encode(eciesCryptogram.getEncryptedData());
-                String mac = BaseEncoding.base64().encode(eciesCryptogram.getMac());
-                requestObject.setEphemeralKey(ephemeralPublicKeyBase64);
-                requestObject.setEncryptedData(encryptedData);
-                requestObject.setMac(mac);
-                request = new ObjectRequest<>(requestObject);
-                break;
-            }
-
-            case "2.1":
-            case "2.0": {
-                uri = model.getUriString() + "/pa/token/create";
-                encryptor = new EciesEncryptor((ECPublicKey) model.getMasterPublicKey(), null, null);
-                eciesCryptogram = encryptor.encryptRequest(new byte[0]);
-                // Prepare encryption request
-                io.getlime.security.powerauth.rest.api.model.request.v2.TokenCreateRequest requestObject = new io.getlime.security.powerauth.rest.api.model.request.v2.TokenCreateRequest();
-                String ephemeralPublicKeyBase64 = BaseEncoding.base64().encode(eciesCryptogram.getEphemeralPublicKey());
-                requestObject.setEphemeralPublicKey(ephemeralPublicKeyBase64);
-                request = new ObjectRequest<>(requestObject);
-                break;
-            }
-
-            default:
-                throw new IllegalStateException("Unsupported version: "+model.getVersion());
-        }
+        final EciesEncryptor encryptor = new EciesEncryptor((ECPublicKey) model.getMasterPublicKey(), null, null);
+        final EciesCryptogram eciesCryptogram = encryptor.encryptRequest(new byte[0]);
+        // Prepare encryption request
+        TokenCreateRequest requestObject = new TokenCreateRequest();
+        String ephemeralPublicKeyBase64 = BaseEncoding.base64().encode(eciesCryptogram.getEphemeralPublicKey());
+        requestObject.setEphemeralPublicKey(ephemeralPublicKeyBase64);
+        final ObjectRequest request = new ObjectRequest<>(requestObject);
 
         final byte[] requestBytes = RestClientConfiguration.defaultMapper().writeValueAsBytes(request);
 

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/PrepareActivationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/PrepareActivationStep.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.getlime.security.powerauth.lib.cmd.steps;
+package io.getlime.security.powerauth.lib.cmd.steps.v2;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,6 +29,7 @@ import io.getlime.security.powerauth.crypto.client.vault.PowerAuthClientVault;
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
 import io.getlime.security.powerauth.lib.cmd.logging.JsonStepLogger;
+import io.getlime.security.powerauth.lib.cmd.steps.BaseStep;
 import io.getlime.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
 import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
 import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
@@ -51,7 +52,13 @@ import java.util.regex.Pattern;
 /**
  * Helper class with prepare activation logic.
  *
- * @author Petr Dvorak
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *     <li>2.0</li>
+ *     <li>2.1</li>
+ * </ul>
+ *
+ * @author Petr Dvorak, petr@wultra.com
  *
  */
 public class PrepareActivationStep implements BaseStep {
@@ -217,14 +224,14 @@ public class PrepareActivationStep implements BaseStep {
                     }
 
                     byte[] salt = keyGenerator.generateRandomBytes(16);
-                    byte[] cSignatureKnoweldgeSecretKey = EncryptedStorageUtil.storeSignatureKnowledgeKey(password, signatureKnoweldgeSecretKey, salt, keyGenerator);
+                    byte[] cSignatureKnowledgeSecretKey = EncryptedStorageUtil.storeSignatureKnowledgeKey(password, signatureKnoweldgeSecretKey, salt, keyGenerator);
 
                     // Prepare the status object to be stored
                     model.getResultStatusObject().put("activationId", activationId);
                     model.getResultStatusObject().put("serverPublicKey", BaseEncoding.base64().encode(keyConversion.convertPublicKeyToBytes(serverPublicKey)));
                     model.getResultStatusObject().put("encryptedDevicePrivateKey", BaseEncoding.base64().encode(encryptedDevicePrivateKey));
                     model.getResultStatusObject().put("signaturePossessionKey", BaseEncoding.base64().encode(keyConversion.convertSharedSecretKeyToBytes(signaturePossessionSecretKey)));
-                    model.getResultStatusObject().put("signatureKnowledgeKeyEncrypted", BaseEncoding.base64().encode(cSignatureKnoweldgeSecretKey));
+                    model.getResultStatusObject().put("signatureKnowledgeKeyEncrypted", BaseEncoding.base64().encode(cSignatureKnowledgeSecretKey));
                     model.getResultStatusObject().put("signatureKnowledgeKeySalt", BaseEncoding.base64().encode(salt));
                     model.getResultStatusObject().put("signatureBiometryKey", BaseEncoding.base64().encode(keyConversion.convertSharedSecretKeyToBytes(signatureBiometrySecretKey)));
                     model.getResultStatusObject().put("transportMasterKey", BaseEncoding.base64().encode(keyConversion.convertSharedSecretKeyToBytes(transportMasterKey)));

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CreateTokenStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CreateTokenStep.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.cmd.steps.v3;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.BaseEncoding;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import io.getlime.security.powerauth.crypto.client.signature.PowerAuthClientSignature;
+import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEncryptor;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesFactory;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesCryptogram;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesSharedInfo1;
+import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.http.PowerAuthHttpBody;
+import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
+import io.getlime.security.powerauth.lib.cmd.logging.JsonStepLogger;
+import io.getlime.security.powerauth.lib.cmd.steps.BaseStep;
+import io.getlime.security.powerauth.lib.cmd.steps.model.CreateTokenStepModel;
+import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
+import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
+import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
+import io.getlime.security.powerauth.provider.CryptoProviderUtil;
+import io.getlime.security.powerauth.rest.api.model.entity.TokenResponsePayload;
+import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
+import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
+import org.json.simple.JSONObject;
+
+import javax.crypto.SecretKey;
+import java.io.Console;
+import java.io.FileWriter;
+import java.nio.charset.StandardCharsets;
+import java.security.interfaces.ECPublicKey;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Helper class with token creation logic.
+ *
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *      <li>3.0</li>
+ * </ul>
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class CreateTokenStep implements BaseStep {
+
+    private static final CryptoProviderUtil keyConversion = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
+    private static final KeyGenerator keyGenerator = new KeyGenerator();
+    private static final PowerAuthClientSignature signature = new PowerAuthClientSignature();
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final EciesFactory eciesFactory = new EciesFactory();
+
+    /**
+     * Execute this step with given context
+     * @param context Provided context
+     * @return Result status object, null in case of failure.
+     * @throws Exception In case of any error.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public JSONObject execute(JsonStepLogger stepLogger, Map<String, Object> context) throws Exception {
+
+        // Read properties from "context"
+        CreateTokenStepModel model = new CreateTokenStepModel();
+        model.fromMap(context);
+
+        if (stepLogger != null) {
+            stepLogger.writeItem(
+                    "Token Create Started",
+                    null,
+                    "OK",
+                    null
+            );
+        }
+
+        // Get data from status
+        String activationId = (String) model.getResultStatusObject().get("activationId");
+        long counter = (long) model.getResultStatusObject().get("counter");
+        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signaturePossessionKey"));
+        byte[] signatureKnowledgeKeySalt = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureKnowledgeKeySalt"));
+        byte[] signatureKnowledgeKeyEncryptedBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureKnowledgeKeyEncrypted"));
+
+        // Ask for the password to unlock knowledge factor key
+        char[] password;
+        if (model.getPassword() == null) {
+            Console console = System.console();
+            password = console.readPassword("Enter your password to unlock the knowledge related key: ");
+        } else {
+            password = model.getPassword().toCharArray();
+        }
+
+        // Get the signature keys
+        SecretKey signaturePossessionKey = keyConversion.convertBytesToSharedSecretKey(signaturePossessionKeyBytes);
+        SecretKey signatureKnowledgeKey = EncryptedStorageUtil.getSignatureKnowledgeKey(password, signatureKnowledgeKeyEncryptedBytes, signatureKnowledgeKeySalt, keyGenerator);
+
+        // Generate nonce
+        byte[] pa_nonce = keyGenerator.generateRandomBytes(16);
+
+        final String uri = model.getUriString() + "/pa/v3/token/create";
+
+        // Prepare ECIES encryptor and encrypt request data with sharedInfo1 = /pa/token/create
+        final byte[] applicationSecret = BaseEncoding.base64().decode(model.getApplicationSecret());
+        final byte[] transportMasterKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("transportMasterKey"));
+        final byte[] serverPublicKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("serverPublicKey"));
+        final ECPublicKey serverPublicKey = (ECPublicKey) keyConversion.convertBytesToPublicKey(serverPublicKeyBytes);
+        final EciesEncryptor encryptor = eciesFactory.getEciesEncryptorForActivation(serverPublicKey, applicationSecret,
+                transportMasterKeyBytes, EciesSharedInfo1.CREATE_TOKEN);
+        final EciesCryptogram eciesCryptogram = encryptor.encryptRequest("{}".getBytes(StandardCharsets.UTF_8));
+
+        // Prepare encrypted request
+        final EciesEncryptedRequest request = new EciesEncryptedRequest();
+        final String ephemeralPublicKeyBase64 = BaseEncoding.base64().encode(eciesCryptogram.getEphemeralPublicKey());
+        final String encryptedData = BaseEncoding.base64().encode(eciesCryptogram.getEncryptedData());
+        final String mac = BaseEncoding.base64().encode(eciesCryptogram.getMac());
+        request.setEphemeralPublicKey(ephemeralPublicKeyBase64);
+        request.setEncryptedData(encryptedData);
+        request.setMac(mac);
+
+        final byte[] requestBytes = RestClientConfiguration.defaultMapper().writeValueAsBytes(request);
+
+        // Compute the current PowerAuth 2.0 signature for possession
+        // and knowledge factor
+        String signatureBaseString = PowerAuthHttpBody.getSignatureBaseString("POST", "/pa/token/create", pa_nonce, requestBytes) + "&" + model.getApplicationSecret();
+        String pa_signature = signature.signatureForData(signatureBaseString.getBytes("UTF-8"), Arrays.asList(signaturePossessionKey, signatureKnowledgeKey), counter);
+        PowerAuthSignatureHttpHeader header = new PowerAuthSignatureHttpHeader(activationId, model.getApplicationKey(), pa_signature, model.getSignatureType().toString(), BaseEncoding.base64().encode(pa_nonce), model.getVersion());
+        String httpAuthorizationHeader = header.buildHttpHeader();
+
+        // Increment the counter
+        counter += 1;
+        model.getResultStatusObject().put("counter", counter);
+
+        // Store the activation status (updated counter)
+        String formatted = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(model.getResultStatusObject());
+        try (FileWriter file = new FileWriter(model.getStatusFileName())) {
+            file.write(formatted);
+        }
+
+        // Call the server with activation data
+        try {
+
+            Map<String, String> headers = new HashMap<>();
+            headers.put("Accept", "application/json");
+            headers.put("Content-Type", "application/json");
+            headers.put(PowerAuthSignatureHttpHeader.HEADER_NAME, httpAuthorizationHeader);
+            headers.putAll(model.getHeaders());
+
+            if (stepLogger != null) {
+                stepLogger.writeServerCall(uri, "POST", request, headers);
+            }
+
+            HttpResponse response = Unirest.post(uri)
+                    .headers(headers)
+                    .body(requestBytes)
+                    .asString();
+
+            if (response.getStatus() == 200) {
+                EciesEncryptedResponse encryptedResponse = RestClientConfiguration
+                        .defaultMapper()
+                        .readValue(response.getRawBody(), EciesEncryptedResponse.class);
+
+                if (stepLogger != null) {
+                    stepLogger.writeServerCallOK(encryptedResponse, HttpUtil.flattenHttpHeaders(response.getHeaders()));
+                }
+
+                byte[] macResponse = BaseEncoding.base64().decode(encryptedResponse.getMac());
+                byte[] encryptedDataResponse = BaseEncoding.base64().decode(encryptedResponse.getEncryptedData());
+                EciesCryptogram eciesCryptogramResponse = new EciesCryptogram(macResponse, encryptedDataResponse);
+
+                final byte[] decryptedBytes = encryptor.decryptResponse(eciesCryptogramResponse);
+
+                final TokenResponsePayload tokenResponsePayload = RestClientConfiguration.defaultMapper().readValue(decryptedBytes, TokenResponsePayload.class);
+
+                Map<String, Object> objectMap = new HashMap<>();
+                objectMap.put("tokenId", tokenResponsePayload.getTokenId());
+                objectMap.put("tokenSecret", tokenResponsePayload.getTokenSecret());
+
+                if (stepLogger != null) {
+                    stepLogger.writeItem(
+                            "Token successfully obtained",
+                            "Token was successfully generated and decrypted",
+                            "OK",
+                            objectMap
+
+                    );
+                    stepLogger.writeDoneOK();
+                }
+
+                return model.getResultStatusObject();
+            } else {
+                if (stepLogger != null) {
+                    stepLogger.writeServerCallError(response.getStatus(), response.getBody(), HttpUtil.flattenHttpHeaders(response.getHeaders()));
+                    stepLogger.writeDoneFailed();
+                }
+                return null;
+            }
+        } catch (UnirestException exception) {
+            if (stepLogger != null) {
+                stepLogger.writeServerCallConnectionError(exception);
+                stepLogger.writeDoneFailed();
+            }
+            return null;
+        } catch (Exception exception) {
+            if (stepLogger != null) {
+                stepLogger.writeError(exception);
+                stepLogger.writeDoneFailed();
+            }
+            return null;
+        }
+    }
+
+}

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/PrepareActivationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/PrepareActivationStep.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2016 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.cmd.steps.v3;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.BaseEncoding;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import io.getlime.security.powerauth.crypto.client.activation.PowerAuthClientActivation;
+import io.getlime.security.powerauth.crypto.client.keyfactory.PowerAuthClientKeyFactory;
+import io.getlime.security.powerauth.crypto.client.vault.PowerAuthClientVault;
+import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEncryptor;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesFactory;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesCryptogram;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesSharedInfo1;
+import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.http.PowerAuthEncryptionHttpHeader;
+import io.getlime.security.powerauth.lib.cmd.logging.JsonStepLogger;
+import io.getlime.security.powerauth.lib.cmd.steps.BaseStep;
+import io.getlime.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
+import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
+import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
+import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
+import io.getlime.security.powerauth.provider.CryptoProviderUtil;
+import io.getlime.security.powerauth.rest.api.model.entity.ActivationType;
+import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
+import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer2Request;
+import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
+import io.getlime.security.powerauth.rest.api.model.response.v3.ActivationLayer2Response;
+import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
+import org.json.simple.JSONObject;
+
+import javax.crypto.SecretKey;
+import java.io.ByteArrayOutputStream;
+import java.io.Console;
+import java.io.FileWriter;
+import java.security.KeyPair;
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Helper class with prepare activation logic.
+ *
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *      <li>3.0</li>
+ * </ul>
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
+ */
+public class PrepareActivationStep implements BaseStep {
+
+    private static final PowerAuthClientActivation activation = new PowerAuthClientActivation();
+    private static final CryptoProviderUtil keyConversion = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
+    private static final PowerAuthClientKeyFactory keyFactory = new PowerAuthClientKeyFactory();
+    private static final KeyGenerator keyGenerator = new KeyGenerator();
+    private static final PowerAuthClientVault vault = new PowerAuthClientVault();
+
+    private final EciesFactory eciesFactory = new EciesFactory();
+    private final ObjectMapper objectMapper = RestClientConfiguration.defaultMapper();
+
+    /**
+     * Execute this step with given context
+     * @param context Provided context
+     * @return Result status object, null in case of failure.
+     * @throws Exception In case of any error.
+     */
+    @SuppressWarnings("unchecked")
+    public JSONObject execute(JsonStepLogger stepLogger, Map<String, Object> context) throws Exception {
+
+        // Read properties from "context"
+        PrepareActivationStepModel model = new PrepareActivationStepModel();
+        model.fromMap(context);
+
+        if (stepLogger != null) {
+            stepLogger.writeItem(
+                    "Activation Started",
+                    null,
+                    "OK",
+                    null
+            );
+        }
+
+        // Prepare the activation URI
+        String uri = model.getUriString() + "/pa/v3/activation/create";
+
+        // Fetch and parse the activation code
+        Pattern p = Pattern.compile("^[A-Z2-7]{5}-[A-Z2-7]{5}-[A-Z2-7]{5}-[A-Z2-7]{5}$");
+        Matcher m = p.matcher(model.getActivationCode());
+        if (!m.find()) {
+            if (stepLogger != null) {
+                stepLogger.writeError("Prepare activation step failed", "Activation code has invalid format");
+                stepLogger.writeDoneFailed();
+                return null;
+            }
+        }
+        final String activationCode = model.getActivationCode();
+
+        Map<String, Object> objectMap = new HashMap<>();
+        objectMap.put("activationCode", activationCode);
+        if (stepLogger != null) {
+            stepLogger.writeItem(
+                    "Activation code",
+                    "Storing activation code",
+                    "OK",
+                    objectMap
+            );
+        }
+
+        // Get activation key and secret
+        final String applicationKey = model.getApplicationKey();
+        final byte[] applicationSecret = BaseEncoding.base64().decode(model.getApplicationSecret());
+
+        // Generate device key pair
+        KeyPair deviceKeyPair = activation.generateDeviceKeyPair();
+        byte[] devicePublicKeyBytes = keyConversion.convertPublicKeyToBytes(deviceKeyPair.getPublic());
+        String devicePublicKeyBase64 = BaseEncoding.base64().encode(devicePublicKeyBytes);
+
+        // Create activation layer 2 request which is decryptable only on PowerAuth server
+        ActivationLayer2Request requestL2 = new ActivationLayer2Request();
+        requestL2.setActivationName(model.getActivationName());
+        requestL2.setDevicePublicKey(devicePublicKeyBase64);
+
+        // Encrypt request data using ECIES in application scope with sharedInfo1 = /pa/activation
+        EciesEncryptor eciesEncryptorL2 = eciesFactory.getEciesEncryptorForApplication((ECPublicKey) model.getMasterPublicKey(), applicationSecret, EciesSharedInfo1.ACTIVATION_LAYER_2);
+        ByteArrayOutputStream baosL2 = new ByteArrayOutputStream();
+        objectMapper.writeValue(baosL2, requestL2);
+        EciesCryptogram eciesCryptogramL2 = eciesEncryptorL2.encryptRequest(baosL2.toByteArray());
+
+        // Prepare the encrypted layer 2 request
+        EciesEncryptedRequest encryptedRequestL2 = new EciesEncryptedRequest();
+        encryptedRequestL2.setEphemeralPublicKey(BaseEncoding.base64().encode(eciesCryptogramL2.getEphemeralPublicKey()));
+        encryptedRequestL2.setEncryptedData(BaseEncoding.base64().encode(eciesCryptogramL2.getEncryptedData()));
+        encryptedRequestL2.setMac(BaseEncoding.base64().encode(eciesCryptogramL2.getMac()));
+
+        // Prepare activation layer 1 request which is decryptable on intermediate server
+        ActivationLayer1Request requestL1 = new ActivationLayer1Request();
+        requestL1.setType(ActivationType.CODE);
+        requestL1.setActivationData(encryptedRequestL2);
+        Map<String, String> identityAttributes = new HashMap<>();
+        identityAttributes.put("code", activationCode);
+        requestL1.setIdentityAttributes(identityAttributes);
+
+        // Encrypt the layer 1 request using ECIES in application scope with sharedInfo1 = /pa/generic/application
+        EciesEncryptor eciesEncryptorL1 = eciesFactory.getEciesEncryptorForApplication((ECPublicKey) model.getMasterPublicKey(), applicationSecret, EciesSharedInfo1.APPLICATION_SCOPE_GENERIC);
+        ByteArrayOutputStream baosL1 = new ByteArrayOutputStream();
+        objectMapper.writeValue(baosL1, requestL1);
+        EciesCryptogram eciesCryptogramL1 = eciesEncryptorL1.encryptRequest(baosL1.toByteArray());
+
+        // Prepare the encrypted layer 1 request
+        EciesEncryptedRequest encryptedRequestL1 = new EciesEncryptedRequest();
+        encryptedRequestL1.setEphemeralPublicKey(BaseEncoding.base64().encode(eciesCryptogramL1.getEphemeralPublicKey()));
+        encryptedRequestL1.setEncryptedData(BaseEncoding.base64().encode(eciesCryptogramL1.getEncryptedData()));
+        encryptedRequestL1.setMac(BaseEncoding.base64().encode(eciesCryptogramL1.getMac()));
+
+        // Prepare the encryption header
+        PowerAuthEncryptionHttpHeader header = new PowerAuthEncryptionHttpHeader(applicationKey, model.getVersion());
+        String httpEncryptionHeader = header.buildHttpHeader();
+
+        // Call the server with encrypted activation request
+        try {
+
+            Map<String, String> headers = new HashMap<>();
+            headers.put("Accept", "application/json");
+            headers.put("Content-Type", "application/json");
+            headers.put(PowerAuthEncryptionHttpHeader.HEADER_NAME, httpEncryptionHeader);
+            headers.putAll(model.getHeaders());
+
+            if (stepLogger != null) {
+                stepLogger.writeServerCall(uri, "POST", encryptedRequestL1, headers);
+            }
+
+            HttpResponse response = Unirest.post(uri)
+                    .headers(headers)
+                    .body(encryptedRequestL1)
+                    .asString();
+
+            if (response.getStatus() == 200) {
+                // Read activation layer 1 response and decrypt it
+                EciesEncryptedResponse encryptedResponseL1 = objectMapper.readValue(response.getRawBody(), EciesEncryptedResponse.class);
+                byte[] macL1 = BaseEncoding.base64().decode(encryptedResponseL1.getMac());
+                byte[] encryptedDataL1 = BaseEncoding.base64().decode(encryptedResponseL1.getEncryptedData());
+                EciesCryptogram responseCryptogramL1 = new EciesCryptogram(macL1, encryptedDataL1);
+                byte[] decryptedDataL1 = eciesEncryptorL1.decryptResponse(responseCryptogramL1);
+
+                if (stepLogger != null) {
+                    stepLogger.writeServerCallOK(new String(decryptedDataL1), HttpUtil.flattenHttpHeaders(response.getHeaders()));
+                }
+
+                // Read activation layer 2 response and decrypt it
+                EciesEncryptedResponse encryptedResponseL2 = objectMapper.readValue(decryptedDataL1, EciesEncryptedResponse.class);
+                byte[] macL2 = BaseEncoding.base64().decode(encryptedResponseL2.getMac());
+                byte[] encryptedDataL2 = BaseEncoding.base64().decode(encryptedResponseL2.getEncryptedData());
+                EciesCryptogram responseCryptogramL2 = new EciesCryptogram(macL2, encryptedDataL2);
+                byte[] decryptedDataL2 = eciesEncryptorL2.decryptResponse(responseCryptogramL2);
+
+                if (stepLogger != null) {
+                    stepLogger.writeServerCallOK(new String(decryptedDataL2), HttpUtil.flattenHttpHeaders(response.getHeaders()));
+                }
+
+                // Convert activation layer 2 response from JSON to object and extract activation parameters
+                ActivationLayer2Response layer2Response = objectMapper.readValue(decryptedDataL2, ActivationLayer2Response.class);
+                String activationId = layer2Response.getActivationId();
+                String ctrDataBase64 = layer2Response.getCtrData();
+                String serverPublicKeyBase64 = layer2Response.getServerPublicKey();
+                PublicKey serverPublicKey = keyConversion.convertBytesToPublicKey(BaseEncoding.base64().decode(serverPublicKeyBase64));
+
+                // Compute master secret key
+                SecretKey masterSecretKey = keyFactory.generateClientMasterSecretKey(deviceKeyPair.getPrivate(), serverPublicKey);
+
+                // Derive PowerAuth keys from master secret key
+                SecretKey signaturePossessionSecretKey = keyFactory.generateClientSignaturePossessionKey(masterSecretKey);
+                SecretKey signatureKnoweldgeSecretKey = keyFactory.generateClientSignatureKnowledgeKey(masterSecretKey);
+                SecretKey signatureBiometrySecretKey = keyFactory.generateClientSignatureBiometryKey(masterSecretKey);
+                SecretKey transportMasterKey = keyFactory.generateServerTransportKey(masterSecretKey);
+                // DO NOT EVER STORE ...
+                SecretKey vaultUnlockMasterKey = keyFactory.generateServerEncryptedVaultKey(masterSecretKey);
+
+                // Encrypt the original device private key using the vault unlock key
+                byte[] encryptedDevicePrivateKey = vault.encryptDevicePrivateKey(deviceKeyPair.getPrivate(), vaultUnlockMasterKey);
+
+                char[] password;
+                if (model.getPassword() == null) {
+                    Console console = System.console();
+                    password = console.readPassword("Select a password to encrypt the knowledge related key: ");
+                } else {
+                    password = model.getPassword().toCharArray();
+                }
+
+                byte[] salt = keyGenerator.generateRandomBytes(16);
+                byte[] cSignatureKnowledgeSecretKey = EncryptedStorageUtil.storeSignatureKnowledgeKey(password, signatureKnoweldgeSecretKey, salt, keyGenerator);
+
+                // Prepare the status object to be stored
+                model.getResultStatusObject().put("activationId", activationId);
+                model.getResultStatusObject().put("serverPublicKey", BaseEncoding.base64().encode(keyConversion.convertPublicKeyToBytes(serverPublicKey)));
+                model.getResultStatusObject().put("encryptedDevicePrivateKey", BaseEncoding.base64().encode(encryptedDevicePrivateKey));
+                model.getResultStatusObject().put("signaturePossessionKey", BaseEncoding.base64().encode(keyConversion.convertSharedSecretKeyToBytes(signaturePossessionSecretKey)));
+                model.getResultStatusObject().put("signatureKnowledgeKeyEncrypted", BaseEncoding.base64().encode(cSignatureKnowledgeSecretKey));
+                model.getResultStatusObject().put("signatureKnowledgeKeySalt", BaseEncoding.base64().encode(salt));
+                model.getResultStatusObject().put("signatureBiometryKey", BaseEncoding.base64().encode(keyConversion.convertSharedSecretKeyToBytes(signatureBiometrySecretKey)));
+                model.getResultStatusObject().put("transportMasterKey", BaseEncoding.base64().encode(keyConversion.convertSharedSecretKeyToBytes(transportMasterKey)));
+                model.getResultStatusObject().put("counter", 0);
+                model.getResultStatusObject().put("ctrData", ctrDataBase64);
+
+                // Store the resulting status
+                String formatted = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(model.getResultStatusObject());
+                try (FileWriter file = new FileWriter(model.getStatusFileName())) {
+                    file.write(formatted);
+                }
+
+                objectMap = new HashMap<>();
+                objectMap.put("activationId", activationId);
+                objectMap.put("activationStatusFile", model.getStatusFileName());
+                objectMap.put("activationStatusFileContent", model.getResultStatusObject());
+                objectMap.put("deviceKeyFingerprint", activation.computeDevicePublicKeyFingerprint(deviceKeyPair.getPublic()));
+                if (stepLogger != null) {
+                    stepLogger.writeItem(
+                            "Activation Done",
+                            "Public key exchange was successfully completed, commit the activation on server",
+                            "OK",
+                            objectMap
+                    );
+                    stepLogger.writeDoneOK();
+                }
+
+                return model.getResultStatusObject();
+            } else {
+                if (stepLogger != null) {
+                    stepLogger.writeServerCallError(response.getStatus(), response.getBody(), HttpUtil.flattenHttpHeaders(response.getHeaders()));
+                    stepLogger.writeDoneFailed();
+                }
+                return null;
+            }
+        } catch (UnirestException exception) {
+            if (stepLogger != null) {
+                stepLogger.writeServerCallConnectionError(exception);
+                stepLogger.writeDoneFailed();
+            }
+            return null;
+        } catch (Exception exception) {
+            if (stepLogger != null) {
+                stepLogger.writeError(exception);
+                stepLogger.writeDoneFailed();
+            }
+            return null;
+        }
+    }
+
+}

--- a/powerauth-java-cmd/src/main/java/io/getlime/security/powerauth/app/cmd/Application.java
+++ b/powerauth-java-cmd/src/main/java/io/getlime/security/powerauth/app/cmd/Application.java
@@ -226,7 +226,27 @@ public class Application {
                     model.setSignatureType(PowerAuthSignatureTypes.getEnumFromString(cmd.getOptionValue("l")));
                     model.setVersion(version);
 
-                    JSONObject result = new CreateTokenStep().execute(stepLogger, model.toMap());
+                    JSONObject result;
+                    switch (version) {
+                        case "3.0":
+                            result = new io.getlime.security.powerauth.lib.cmd.steps.v3.CreateTokenStep().execute(stepLogger, model.toMap());
+                            break;
+
+                        case "2.0":
+                        case "2.1":
+                            result = new io.getlime.security.powerauth.lib.cmd.steps.v2.CreateTokenStep().execute(stepLogger, model.toMap());
+                            break;
+
+                        default:
+                            stepLogger.writeItem(
+                                    "Unsupported version",
+                                    "The version you specified is not supported",
+                                    "ERROR",
+                                    null
+                            );
+                            throw new ExecutionException();
+                    }
+
                     if (result == null) {
                         throw new ExecutionException();
                     }
@@ -267,7 +287,26 @@ public class Application {
                     model.setUriString(uriString);
                     model.setVersion(version);
 
-                    JSONObject result = new PrepareActivationStep().execute(stepLogger, model.toMap());
+                    JSONObject result;
+                    switch (version) {
+                        case "3.0":
+                            result = new io.getlime.security.powerauth.lib.cmd.steps.v3.PrepareActivationStep().execute(stepLogger, model.toMap());
+                            break;
+
+                        case "2.0":
+                        case "2.1":
+                            result = new io.getlime.security.powerauth.lib.cmd.steps.v2.PrepareActivationStep().execute(stepLogger, model.toMap());
+                            break;
+
+                        default:
+                            stepLogger.writeItem(
+                                    "Unsupported version",
+                                    "The version you specified is not supported",
+                                    "ERROR",
+                                    null
+                            );
+                            throw new ExecutionException();
+                    }
                     if (result == null) {
                         throw new ExecutionException();
                     }


### PR DESCRIPTION
Changes in this PR:
- Fix #43: Crypto 3.0: New activation
- Versioning of steps changed to class level, there are too many changes in activation
- Use shared EciesEncryptedRequest and EciesEncryptedResponse for V3 tokens and activation
- Fixed typos and removed PowerAuth 2.0 version

Note that V3 signature related changes are out of scope of this pull request to keep the changes smaller and easier to review.