### PR TITLE
Fix #49: Null pointer exception when HTTP method is missing for validate token

### DIFF
--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/VerifySignatureStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/VerifySignatureStep.java
@@ -32,10 +32,7 @@ import io.getlime.security.powerauth.http.PowerAuthRequestCanonizationUtils;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.lib.cmd.logging.StepLogger;
 import io.getlime.security.powerauth.lib.cmd.steps.model.VerifySignatureStepModel;
-import io.getlime.security.powerauth.lib.cmd.util.CounterUtil;
-import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
-import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
-import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
+import io.getlime.security.powerauth.lib.cmd.util.*;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import org.json.simple.JSONObject;
 
@@ -92,12 +89,12 @@ public class VerifySignatureStep implements BaseStep {
         }
 
         // Get data from status
-        String activationId = (String) model.getResultStatusObject().get("activationId");
-        long counter = (long) model.getResultStatusObject().get("counter");
-        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signaturePossessionKey"));
-        byte[] signatureBiometryKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureBiometryKey"));
-        byte[] signatureKnowledgeKeySalt = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureKnowledgeKeySalt"));
-        byte[] signatureKnowledgeKeyEncryptedBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureKnowledgeKeyEncrypted"));
+        String activationId = JsonUtil.stringValue(model.getResultStatusObject(), "activationId");
+        long counter = JsonUtil.longValue(model.getResultStatusObject(), ("counter"));
+        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signaturePossessionKey"));
+        byte[] signatureBiometryKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureBiometryKey"));
+        byte[] signatureKnowledgeKeySalt = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureKnowledgeKeySalt"));
+        byte[] signatureKnowledgeKeyEncryptedBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureKnowledgeKeyEncrypted"));
 
         // Ask for the password to unlock knowledge factor key
         char[] password;
@@ -180,7 +177,7 @@ public class VerifySignatureStep implements BaseStep {
 
             Map<String, String> lowLevelData = new HashMap<>();
             lowLevelData.put("counter", String.valueOf(counter));
-            int version = (int) model.getResultStatusObject().get("version");
+            int version = JsonUtil.intValue(model.getResultStatusObject(), "version");
             if (version == 3) {
                 lowLevelData.put("ctrData", BaseEncoding.base64().encode(ctrData));
             }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/VerifyTokenStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/VerifyTokenStep.java
@@ -84,6 +84,14 @@ public class VerifyTokenStep implements BaseStep {
                 model.getVersion()
         ).buildHttpHeader();
 
+        if (model.getHttpMethod() == null) {
+            if (stepLogger != null) {
+                stepLogger.writeError("HTTP method not specified", "Specify HTTP method to use for sending request");
+                stepLogger.writeDoneFailed();
+            }
+            return null;
+        }
+
         // Construct the signature base string data part based on HTTP method (GET requires different code).
         byte[] dataFileBytes = null;
         if (!"GET".equals(model.getHttpMethod().toUpperCase())) {

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/CreateActivationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/CreateActivationStep.java
@@ -319,7 +319,7 @@ public class CreateActivationStep implements BaseStep {
                     model.getResultStatusObject().put("transportMasterKey", BaseEncoding.base64().encode(keyConversion.convertSharedSecretKeyToBytes(transportMasterKey)));
                     model.getResultStatusObject().put("counter", 0L);
                     model.getResultStatusObject().put("ctrData", null);
-                    model.getResultStatusObject().put("version", 2);
+                    model.getResultStatusObject().put("version", 2L);
 
                     // Store the resulting status
                     String formatted = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(model.getResultStatusObject());

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/CreateTokenStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/CreateTokenStep.java
@@ -34,10 +34,7 @@ import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.lib.cmd.logging.StepLogger;
 import io.getlime.security.powerauth.lib.cmd.steps.BaseStep;
 import io.getlime.security.powerauth.lib.cmd.steps.model.CreateTokenStepModel;
-import io.getlime.security.powerauth.lib.cmd.util.CounterUtil;
-import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
-import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
-import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
+import io.getlime.security.powerauth.lib.cmd.util.*;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.rest.api.model.entity.TokenResponsePayload;
 import io.getlime.security.powerauth.rest.api.model.request.v2.TokenCreateRequest;
@@ -94,10 +91,10 @@ public class CreateTokenStep implements BaseStep {
         }
 
         // Get data from status
-        String activationId = (String) model.getResultStatusObject().get("activationId");
-        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signaturePossessionKey"));
-        byte[] signatureKnowledgeKeySalt = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureKnowledgeKeySalt"));
-        byte[] signatureKnowledgeKeyEncryptedBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureKnowledgeKeyEncrypted"));
+        String activationId = JsonUtil.stringValue(model.getResultStatusObject(), "activationId");
+        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signaturePossessionKey"));
+        byte[] signatureKnowledgeKeySalt = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureKnowledgeKeySalt"));
+        byte[] signatureKnowledgeKeyEncryptedBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureKnowledgeKeyEncrypted"));
 
         // Ask for the password to unlock knowledge factor key
         char[] password;

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/GetStatusStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/GetStatusStep.java
@@ -30,6 +30,7 @@ import io.getlime.security.powerauth.lib.cmd.logging.StepLogger;
 import io.getlime.security.powerauth.lib.cmd.steps.BaseStep;
 import io.getlime.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
 import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
+import io.getlime.security.powerauth.lib.cmd.util.JsonUtil;
 import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.rest.api.model.request.v2.ActivationStatusRequest;
@@ -83,8 +84,8 @@ public class GetStatusStep implements BaseStep {
         String uri = model.getUriString() + "/pa/activation/status";
 
         // Get data from status
-        String activationId = (String) model.getResultStatusObject().get("activationId");
-        String transportMasterKeyBase64 = (String) model.getResultStatusObject().get("transportMasterKey");
+        String activationId = JsonUtil.stringValue(model.getResultStatusObject(), "activationId");
+        String transportMasterKeyBase64 = JsonUtil.stringValue(model.getResultStatusObject(), "transportMasterKey");
         SecretKey transportMasterKey = keyConversion.convertBytesToSharedSecretKey(BaseEncoding.base64().decode(transportMasterKeyBase64));
 
         // Send the activation status request to the server

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/PrepareActivationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/PrepareActivationStep.java
@@ -238,7 +238,7 @@ public class PrepareActivationStep implements BaseStep {
                     model.getResultStatusObject().put("transportMasterKey", BaseEncoding.base64().encode(keyConversion.convertSharedSecretKeyToBytes(transportMasterKey)));
                     model.getResultStatusObject().put("counter", 0L);
                     model.getResultStatusObject().put("ctrData", null);
-                    model.getResultStatusObject().put("version", 2);
+                    model.getResultStatusObject().put("version", 2L);
 
                     // Store the resulting status
                     String formatted = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(model.getResultStatusObject());

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/RemoveStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/RemoveStep.java
@@ -32,10 +32,7 @@ import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.lib.cmd.logging.StepLogger;
 import io.getlime.security.powerauth.lib.cmd.steps.BaseStep;
 import io.getlime.security.powerauth.lib.cmd.steps.model.RemoveStepModel;
-import io.getlime.security.powerauth.lib.cmd.util.CounterUtil;
-import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
-import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
-import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
+import io.getlime.security.powerauth.lib.cmd.util.*;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.rest.api.model.response.v2.ActivationRemoveResponse;
 import org.json.simple.JSONObject;
@@ -91,10 +88,10 @@ public class RemoveStep implements BaseStep {
         String uri = model.getUriString() + "/pa/activation/remove";
 
         // Get data from status
-        String activationId = (String) model.getResultStatusObject().get("activationId");
-        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signaturePossessionKey"));
-        byte[] signatureKnowledgeKeySalt = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureKnowledgeKeySalt"));
-        byte[] signatureKnowledgeKeyEncryptedBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureKnowledgeKeyEncrypted"));
+        String activationId = JsonUtil.stringValue(model.getResultStatusObject(), "activationId");
+        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signaturePossessionKey"));
+        byte[] signatureKnowledgeKeySalt = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureKnowledgeKeySalt"));
+        byte[] signatureKnowledgeKeyEncryptedBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureKnowledgeKeyEncrypted"));
 
         // Ask for the password to unlock knowledge factor key
         char[] password;

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/VaultUnlockStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/VaultUnlockStep.java
@@ -34,10 +34,7 @@ import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.lib.cmd.logging.StepLogger;
 import io.getlime.security.powerauth.lib.cmd.steps.BaseStep;
 import io.getlime.security.powerauth.lib.cmd.steps.model.VaultUnlockStepModel;
-import io.getlime.security.powerauth.lib.cmd.util.CounterUtil;
-import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
-import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
-import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
+import io.getlime.security.powerauth.lib.cmd.util.*;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.rest.api.model.request.v2.VaultUnlockRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v2.VaultUnlockResponse;
@@ -97,14 +94,14 @@ public class VaultUnlockStep implements BaseStep {
         String uri = model.getUriString() + "/pa/vault/unlock";
 
         // Get data from status
-        String activationId = (String) model.getResultStatusObject().get("activationId");
-        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signaturePossessionKey"));
-        byte[] signatureBiometryKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureBiometryKey"));
-        byte[] signatureKnowledgeKeySalt = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureKnowledgeKeySalt"));
-        byte[] signatureKnowledgeKeyEncryptedBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureKnowledgeKeyEncrypted"));
-        byte[] transportMasterKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("transportMasterKey"));
-        byte[] encryptedDevicePrivateKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("encryptedDevicePrivateKey"));
-        byte[] serverPublicKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("serverPublicKey"));
+        String activationId = JsonUtil.stringValue(model.getResultStatusObject(), "activationId");
+        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signaturePossessionKey"));
+        byte[] signatureBiometryKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureBiometryKey"));
+        byte[] signatureKnowledgeKeySalt = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureKnowledgeKeySalt"));
+        byte[] signatureKnowledgeKeyEncryptedBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureKnowledgeKeyEncrypted"));
+        byte[] transportMasterKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "transportMasterKey"));
+        byte[] encryptedDevicePrivateKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "encryptedDevicePrivateKey"));
+        byte[] serverPublicKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "serverPublicKey"));
 
         // Ask for the password to unlock knowledge factor key
         char[] password;

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CommitUpgradeStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CommitUpgradeStep.java
@@ -32,6 +32,7 @@ import io.getlime.security.powerauth.lib.cmd.steps.BaseStep;
 import io.getlime.security.powerauth.lib.cmd.steps.model.StartUpgradeStepModel;
 import io.getlime.security.powerauth.lib.cmd.util.CounterUtil;
 import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
+import io.getlime.security.powerauth.lib.cmd.util.JsonUtil;
 import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import org.json.simple.JSONObject;
@@ -83,10 +84,10 @@ public class CommitUpgradeStep implements BaseStep {
         }
 
         final String uri = model.getUriString() + "/pa/v3/upgrade/commit";
-        final String activationId = (String) model.getResultStatusObject().get("activationId");
+        final String activationId = JsonUtil.stringValue(model.getResultStatusObject(), "activationId");
 
         // Get the signature key (possession factor)
-        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signaturePossessionKey"));
+        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signaturePossessionKey"));
         final SecretKey signaturePossessionKey = keyConversion.convertBytesToSharedSecretKey(signaturePossessionKeyBytes);
 
         // Generate nonce
@@ -97,7 +98,7 @@ public class CommitUpgradeStep implements BaseStep {
         byte[] requestBytes = request.getBytes(StandardCharsets.UTF_8);
 
         // Make sure hash based counter is used for calculating the signature, in case of an error the version change is not saved
-        model.getResultStatusObject().put("version", 3);
+        model.getResultStatusObject().put("version", 3L);
 
         // Compute PowerAuth signature for possession factor
         String signatureBaseString = PowerAuthHttpBody.getSignatureBaseString("POST", "/pa/upgrade/commit", pa_nonce, requestBytes) + "&" + model.getApplicationSecret();
@@ -154,7 +155,7 @@ public class CommitUpgradeStep implements BaseStep {
                 return model.getResultStatusObject();
             } else {
                 // Revert upgrade to version 3 because signature failed. The status file was not changed, so no need to save it.
-                model.getResultStatusObject().put("version", 2);
+                model.getResultStatusObject().put("version", 2L);
 
                 if (stepLogger != null) {
                     stepLogger.writeServerCallError(response.getStatus(), response.getBody(), HttpUtil.flattenHttpHeaders(response.getHeaders()));

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CreateTokenStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CreateTokenStep.java
@@ -33,10 +33,7 @@ import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.lib.cmd.logging.StepLogger;
 import io.getlime.security.powerauth.lib.cmd.steps.BaseStep;
 import io.getlime.security.powerauth.lib.cmd.steps.model.CreateTokenStepModel;
-import io.getlime.security.powerauth.lib.cmd.util.CounterUtil;
-import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
-import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
-import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
+import io.getlime.security.powerauth.lib.cmd.util.*;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.rest.api.model.entity.TokenResponsePayload;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
@@ -94,10 +91,10 @@ public class CreateTokenStep implements BaseStep {
         }
 
         // Get data from status
-        String activationId = (String) model.getResultStatusObject().get("activationId");
-        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signaturePossessionKey"));
-        byte[] signatureKnowledgeKeySalt = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureKnowledgeKeySalt"));
-        byte[] signatureKnowledgeKeyEncryptedBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureKnowledgeKeyEncrypted"));
+        String activationId = JsonUtil.stringValue(model.getResultStatusObject(), "activationId");
+        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signaturePossessionKey"));
+        byte[] signatureKnowledgeKeySalt = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureKnowledgeKeySalt"));
+        byte[] signatureKnowledgeKeyEncryptedBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureKnowledgeKeyEncrypted"));
 
         // Ask for the password to unlock knowledge factor key
         char[] password;
@@ -119,8 +116,8 @@ public class CreateTokenStep implements BaseStep {
 
         // Prepare ECIES encryptor and encrypt request data with sharedInfo1 = /pa/token/create
         final byte[] applicationSecret = model.getApplicationSecret().getBytes(StandardCharsets.UTF_8);
-        final byte[] transportMasterKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("transportMasterKey"));
-        final byte[] serverPublicKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("serverPublicKey"));
+        final byte[] transportMasterKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "transportMasterKey"));
+        final byte[] serverPublicKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "serverPublicKey"));
         final ECPublicKey serverPublicKey = (ECPublicKey) keyConversion.convertBytesToPublicKey(serverPublicKeyBytes);
         final EciesEncryptor encryptor = eciesFactory.getEciesEncryptorForActivation(serverPublicKey, applicationSecret,
                 transportMasterKeyBytes, EciesSharedInfo1.CREATE_TOKEN);

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/GetStatusStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/GetStatusStep.java
@@ -29,6 +29,7 @@ import io.getlime.security.powerauth.lib.cmd.logging.StepLogger;
 import io.getlime.security.powerauth.lib.cmd.steps.BaseStep;
 import io.getlime.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
 import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
+import io.getlime.security.powerauth.lib.cmd.util.JsonUtil;
 import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationStatusRequest;
@@ -81,8 +82,8 @@ public class GetStatusStep implements BaseStep {
         String uri = model.getUriString() + "/pa/v3/activation/status";
 
         // Get data from status
-        String activationId = (String) model.getResultStatusObject().get("activationId");
-        String transportMasterKeyBase64 = (String) model.getResultStatusObject().get("transportMasterKey");
+        String activationId = JsonUtil.stringValue(model.getResultStatusObject(), "activationId");
+        String transportMasterKeyBase64 = JsonUtil.stringValue(model.getResultStatusObject(), "transportMasterKey");
         SecretKey transportMasterKey = keyConversion.convertBytesToSharedSecretKey(BaseEncoding.base64().decode(transportMasterKeyBase64));
 
         // Send the activation status request to the server

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/PrepareActivationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/PrepareActivationStep.java
@@ -282,7 +282,7 @@ public class PrepareActivationStep implements BaseStep {
                 model.getResultStatusObject().put("transportMasterKey", BaseEncoding.base64().encode(keyConversion.convertSharedSecretKeyToBytes(transportMasterKey)));
                 model.getResultStatusObject().put("counter", 0L);
                 model.getResultStatusObject().put("ctrData", ctrDataBase64);
-                model.getResultStatusObject().put("version", 3);
+                model.getResultStatusObject().put("version", 3L);
 
                 // Store the resulting status
                 String formatted = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(model.getResultStatusObject());

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/RemoveStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/RemoveStep.java
@@ -31,10 +31,7 @@ import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.lib.cmd.logging.StepLogger;
 import io.getlime.security.powerauth.lib.cmd.steps.BaseStep;
 import io.getlime.security.powerauth.lib.cmd.steps.model.RemoveStepModel;
-import io.getlime.security.powerauth.lib.cmd.util.CounterUtil;
-import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
-import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
-import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
+import io.getlime.security.powerauth.lib.cmd.util.*;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.rest.api.model.response.v2.ActivationRemoveResponse;
 import org.json.simple.JSONObject;
@@ -89,10 +86,10 @@ public class RemoveStep implements BaseStep {
         String uri = model.getUriString() + "/pa/v3/activation/remove";
 
         // Get data from status
-        String activationId = (String) model.getResultStatusObject().get("activationId");
-        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signaturePossessionKey"));
-        byte[] signatureKnowledgeKeySalt = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureKnowledgeKeySalt"));
-        byte[] signatureKnowledgeKeyEncryptedBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureKnowledgeKeyEncrypted"));
+        String activationId = JsonUtil.stringValue(model.getResultStatusObject(), "activationId");
+        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signaturePossessionKey"));
+        byte[] signatureKnowledgeKeySalt = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureKnowledgeKeySalt"));
+        byte[] signatureKnowledgeKeyEncryptedBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureKnowledgeKeyEncrypted"));
 
         // Ask for the password to unlock knowledge factor key
         char[] password;

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/StartUpgradeStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/StartUpgradeStep.java
@@ -30,6 +30,7 @@ import io.getlime.security.powerauth.lib.cmd.logging.StepLogger;
 import io.getlime.security.powerauth.lib.cmd.steps.BaseStep;
 import io.getlime.security.powerauth.lib.cmd.steps.model.StartUpgradeStepModel;
 import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
+import io.getlime.security.powerauth.lib.cmd.util.JsonUtil;
 import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
@@ -84,12 +85,12 @@ public class StartUpgradeStep implements BaseStep {
 
         final String uri = model.getUriString() + "/pa/v3/upgrade/start";
         final String applicationKey = model.getApplicationKey();
-        final String activationId = (String) model.getResultStatusObject().get("activationId");
+        final String activationId = JsonUtil.stringValue(model.getResultStatusObject(), "activationId");
 
         // Prepare ECIES encryptor and encrypt request data with sharedInfo1 = /pa/upgrade
         byte[] applicationSecret = model.getApplicationSecret().getBytes(StandardCharsets.UTF_8);
-        byte[] transportMasterKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("transportMasterKey"));
-        byte[] serverPublicKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("serverPublicKey"));
+        byte[] transportMasterKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "transportMasterKey"));
+        byte[] serverPublicKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "serverPublicKey"));
         final ECPublicKey serverPublicKey = (ECPublicKey) keyConversion.convertBytesToPublicKey(serverPublicKeyBytes);
         final EciesEncryptor encryptor = eciesFactory.getEciesEncryptorForActivation(serverPublicKey, applicationSecret,
                 transportMasterKeyBytes, EciesSharedInfo1.UPGRADE);

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/VaultUnlockStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/VaultUnlockStep.java
@@ -34,10 +34,7 @@ import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.lib.cmd.logging.StepLogger;
 import io.getlime.security.powerauth.lib.cmd.steps.BaseStep;
 import io.getlime.security.powerauth.lib.cmd.steps.model.VaultUnlockStepModel;
-import io.getlime.security.powerauth.lib.cmd.util.CounterUtil;
-import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
-import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
-import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
+import io.getlime.security.powerauth.lib.cmd.util.*;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.request.v3.VaultUnlockRequestPayload;
@@ -100,14 +97,14 @@ public class VaultUnlockStep implements BaseStep {
         String uri = model.getUriString() + "/pa/v3/vault/unlock";
 
         // Get data from status
-        String activationId = (String) model.getResultStatusObject().get("activationId");
-        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signaturePossessionKey"));
-        byte[] signatureBiometryKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureBiometryKey"));
-        byte[] signatureKnowledgeKeySalt = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureKnowledgeKeySalt"));
-        byte[] signatureKnowledgeKeyEncryptedBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("signatureKnowledgeKeyEncrypted"));
-        byte[] transportMasterKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("transportMasterKey"));
-        byte[] encryptedDevicePrivateKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("encryptedDevicePrivateKey"));
-        byte[] serverPublicKeyBytes = BaseEncoding.base64().decode((String) model.getResultStatusObject().get("serverPublicKey"));
+        String activationId = JsonUtil.stringValue(model.getResultStatusObject(), "activationId");
+        byte[] signaturePossessionKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signaturePossessionKey"));
+        byte[] signatureBiometryKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureBiometryKey"));
+        byte[] signatureKnowledgeKeySalt = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureKnowledgeKeySalt"));
+        byte[] signatureKnowledgeKeyEncryptedBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureKnowledgeKeyEncrypted"));
+        byte[] transportMasterKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "transportMasterKey"));
+        byte[] encryptedDevicePrivateKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "encryptedDevicePrivateKey"));
+        byte[] serverPublicKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "serverPublicKey"));
 
         // Ask for the password to unlock knowledge factor key
         char[] password;

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/CounterUtil.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/CounterUtil.java
@@ -21,6 +21,7 @@ import io.getlime.security.powerauth.crypto.lib.generator.HashBasedCounter;
 import io.getlime.security.powerauth.lib.cmd.logging.StepLogger;
 import io.getlime.security.powerauth.lib.cmd.steps.model.BaseStepModel;
 
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 
 /**
@@ -40,8 +41,8 @@ public class CounterUtil {
      */
     public static byte[] getCtrData(BaseStepModel model, StepLogger stepLogger) {
         byte[] ctrData = new byte[16];
-        long counter = (long) model.getResultStatusObject().get("counter");
-        int version = (int) model.getResultStatusObject().get("version");
+        long counter = new BigDecimal(model.getResultStatusObject().get("counter").toString()).longValue();
+        int version = new BigDecimal(model.getResultStatusObject().get("version").toString()).intValue();
         switch (version) {
             case 2:
                 ctrData = ByteBuffer.allocate(16).putLong(8, counter).array();
@@ -72,12 +73,12 @@ public class CounterUtil {
     @SuppressWarnings("unchecked")
     public static void incrementCounter(BaseStepModel model) {
         // Increment the numeric counter
-        long counter = (long) model.getResultStatusObject().get("counter");
+        long counter = new BigDecimal(model.getResultStatusObject().get("counter").toString()).longValue();
         counter += 1;
         model.getResultStatusObject().put("counter", counter);
 
         // Increment the hash based counter in case activation version is 3.
-        int version = (int) model.getResultStatusObject().get("version");
+        int version = new BigDecimal(model.getResultStatusObject().get("version").toString()).intValue();
         if (version == 3) {
             String ctrDataBase64 = (String) model.getResultStatusObject().get("ctrData");
             if (ctrDataBase64 != null) {

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/CounterUtil.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/CounterUtil.java
@@ -21,7 +21,6 @@ import io.getlime.security.powerauth.crypto.lib.generator.HashBasedCounter;
 import io.getlime.security.powerauth.lib.cmd.logging.StepLogger;
 import io.getlime.security.powerauth.lib.cmd.steps.model.BaseStepModel;
 
-import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 
 /**
@@ -41,14 +40,14 @@ public class CounterUtil {
      */
     public static byte[] getCtrData(BaseStepModel model, StepLogger stepLogger) {
         byte[] ctrData = new byte[16];
-        long counter = new BigDecimal(model.getResultStatusObject().get("counter").toString()).longValue();
-        int version = new BigDecimal(model.getResultStatusObject().get("version").toString()).intValue();
+        long counter = JsonUtil.longValue(model.getResultStatusObject(), "counter");
+        int version = JsonUtil.intValue(model.getResultStatusObject(), "version");
         switch (version) {
             case 2:
                 ctrData = ByteBuffer.allocate(16).putLong(8, counter).array();
                 break;
             case 3:
-                String ctrDataBase64 = (String) model.getResultStatusObject().get("ctrData");
+                String ctrDataBase64 = JsonUtil.stringValue(model.getResultStatusObject(), "ctrData");
                 if (ctrDataBase64 != null) {
                     ctrData = BaseEncoding.base64().decode(ctrDataBase64);
                 }
@@ -73,14 +72,14 @@ public class CounterUtil {
     @SuppressWarnings("unchecked")
     public static void incrementCounter(BaseStepModel model) {
         // Increment the numeric counter
-        long counter = new BigDecimal(model.getResultStatusObject().get("counter").toString()).longValue();
+        long counter = JsonUtil.longValue(model.getResultStatusObject(), "counter");
         counter += 1;
         model.getResultStatusObject().put("counter", counter);
 
         // Increment the hash based counter in case activation version is 3.
-        int version = new BigDecimal(model.getResultStatusObject().get("version").toString()).intValue();
+        int version = JsonUtil.intValue(model.getResultStatusObject(), "version");
         if (version == 3) {
-            String ctrDataBase64 = (String) model.getResultStatusObject().get("ctrData");
+            String ctrDataBase64 = JsonUtil.stringValue(model.getResultStatusObject(), "ctrData");
             if (ctrDataBase64 != null) {
                 byte[] ctrData = BaseEncoding.base64().decode(ctrDataBase64);
                 ctrData = new HashBasedCounter().next(ctrData);

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/JsonUtil.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/JsonUtil.java
@@ -1,0 +1,80 @@
+/*
+ * PowerAuth Command-line utility
+ * Copyright 2018 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.cmd.util;
+
+import org.json.simple.JSONObject;
+
+/**
+ * Helper class for obtaining typed values from JSON.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
+ */
+public class JsonUtil {
+
+    /**
+     * Extract long value from JSON object stored using key with given key. In case the deserialized value type
+     * is not numeric, value 0 is returned.
+     * @param o JSON object.
+     * @param key Key name.
+     * @return Extracted long value.
+     */
+    public static long longValue(JSONObject o, String key) {
+        return safeLong(o.get(key));
+    }
+
+    /**
+     * Extract int value from JSON object stored using key with given key. In case the deserialized value type
+     * is not numeric, value 0 is returned.
+     * @param o JSON object.
+     * @param key Key name.
+     * @return Extracted int value.
+     */
+    public static int intValue(JSONObject o, String key) {
+        return (int) safeLong(o.get(key));
+    }
+
+    /**
+     * Extract String value from JSON object stored using key with given name. In case the deserialized value type
+     * is not of String type, value "" is returned.
+     * @param o JSON object.
+     * @param key Key name.
+     * @return Extracted String value.
+     */
+    public static String stringValue(JSONObject o, String key) {
+        return safeString(o.get(key));
+    }
+
+    /**
+     * Convert Object which is expected to contain long value to long.
+     * @param o Object with expected long value.
+     * @return The long value.
+     */
+    private static long safeLong(Object o) {
+        return o instanceof Long ? (long) o : 0;
+    }
+
+    /**
+     * Convert Object which is expected to contain String value to String.
+     * @param o Object with expected String value.
+     * @return The String value.
+     */
+    private static String safeString(Object o) {
+        return o instanceof String ? (String) o : "";
+    }
+
+}

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/RestClientConfiguration.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/RestClientConfiguration.java
@@ -38,6 +38,7 @@ public class RestClientConfiguration {
         mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(DeserializationFeature.USE_LONG_FOR_INTS, true);
     }
 
     /**


### PR DESCRIPTION
This PR fixes:
- Fix #49: Null pointer exception when HTTP method is missing for validate token
- Avoid casts in `CounterUtil`, in memory type of result status object may differ from type stored in file