### PR TITLE
Fix #75: Crypto 3.0: Handle new exceptions from powerauth-crypto

### DIFF
--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CommitUpgradeStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CommitUpgradeStep.java
@@ -99,16 +99,15 @@ public class CommitUpgradeStep implements BaseStep {
         // Make sure hash based counter is used for calculating the signature, in case of an error the version change is not saved
         model.getResultStatusObject().put("version", 3);
 
-        // Compute PowerAuth signature for possession factor
-        String signatureBaseString = PowerAuthHttpBody.getSignatureBaseString("POST", "/pa/upgrade/commit", pa_nonce, requestBytes) + "&" + model.getApplicationSecret();
-        byte[] ctrData = CounterUtil.getCtrData(model, stepLogger);
-        String pa_signature = signature.signatureForData(signatureBaseString.getBytes(StandardCharsets.UTF_8), Collections.singletonList(signaturePossessionKey), ctrData);
-        PowerAuthSignatureHttpHeader header = new PowerAuthSignatureHttpHeader(activationId, model.getApplicationKey(), pa_signature, PowerAuthSignatureTypes.POSSESSION.toString(), BaseEncoding.base64().encode(pa_nonce), model.getVersion());
-        String httpAuthorizationHeader = header.buildHttpHeader();
-
-        // Commit upgrade
         try {
+            // Compute PowerAuth signature for possession factor
+            String signatureBaseString = PowerAuthHttpBody.getSignatureBaseString("POST", "/pa/upgrade/commit", pa_nonce, requestBytes) + "&" + model.getApplicationSecret();
+            byte[] ctrData = CounterUtil.getCtrData(model, stepLogger);
+            String pa_signature = signature.signatureForData(signatureBaseString.getBytes(StandardCharsets.UTF_8), Collections.singletonList(signaturePossessionKey), ctrData);
+            PowerAuthSignatureHttpHeader header = new PowerAuthSignatureHttpHeader(activationId, model.getApplicationKey(), pa_signature, PowerAuthSignatureTypes.POSSESSION.toString(), BaseEncoding.base64().encode(pa_nonce), model.getVersion());
+            String httpAuthorizationHeader = header.buildHttpHeader();
 
+            // Commit upgrade
             Map<String, String> headers = new HashMap<>();
             headers.put("Accept", "application/json");
             headers.put("Content-Type", "application/json");

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/ConfigurationUtil.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/ConfigurationUtil.java
@@ -96,7 +96,7 @@ public class ConfigurationUtil {
                 stepLogger.writeDoneFailed();
                 System.exit(1);
             } catch (CryptoProviderException e) {
-                stepLogger.writeError("Cryptography Provider Error", "Cryptography provider is is initialized incorrectly", e);
+                stepLogger.writeError("Cryptography Provider Error", "Cryptography provider is initialized incorrectly", e);
                 stepLogger.writeDoneFailed();
                 System.exit(1);
             }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/ConfigurationUtil.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/ConfigurationUtil.java
@@ -19,6 +19,7 @@ package io.getlime.security.powerauth.lib.cmd.util;
 import com.google.common.io.BaseEncoding;
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.lib.cmd.logging.JsonStepLogger;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 import org.json.simple.JSONObject;
 
 import java.security.PublicKey;
@@ -92,6 +93,10 @@ public class ConfigurationUtil {
                 System.exit(1);
             } catch (InvalidKeySpecException e) {
                 stepLogger.writeError("Invalid Master Server Public Key", "Master Server Public Key was stored in an incorrect format", e);
+                stepLogger.writeDoneFailed();
+                System.exit(1);
+            } catch (CryptoProviderException e) {
+                stepLogger.writeError("Cryptography Provider Error", "Cryptography provider is is initialized incorrectly", e);
                 stepLogger.writeDoneFailed();
                 System.exit(1);
             }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/EncryptedStorageUtil.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/EncryptedStorageUtil.java
@@ -18,10 +18,10 @@ package io.getlime.security.powerauth.lib.cmd.util;
 
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
-import javax.crypto.BadPaddingException;
-import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
 
@@ -41,10 +41,10 @@ public class EncryptedStorageUtil {
      * @param keyGenerator Key generator instance.
      * @return Encrypted KEY_SIGNATURE_KNOWLEDGE using password and random salt.
      * @throws InvalidKeyException In case invalid key is provided.
-     * @throws IllegalBlockSizeException In case invalid key is provided.
-     * @throws BadPaddingException In case invalid padding is provided.
+     * @throws CryptoProviderException In case cryptography provider is initialized incorrectly.
+     * @throws GenericCryptoException In case any other cryptography error occurs.
      */
-    public static byte[] storeSignatureKnowledgeKey(char[] password, SecretKey signatureKnowledgeSecretKey, byte[] salt, KeyGenerator keyGenerator) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+    public static byte[] storeSignatureKnowledgeKey(char[] password, SecretKey signatureKnowledgeSecretKey, byte[] salt, KeyGenerator keyGenerator) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         // Ask for the password and generate storage key
         SecretKey encryptionSignatureKnowledgeKey = keyGenerator.deriveSecretKeyFromPassword(new String(password), salt);
 
@@ -59,22 +59,22 @@ public class EncryptedStorageUtil {
     /**
      * Decrypt the KEY_SIGNATURE_KNOWLEDGE key using a provided password.
      * @param password Password to be used for decryption.
-     * @param cSignatureKnoweldgeSecretKeyBytes Encrypted KEY_SIGNATURE_KNOWLEDGE key.
+     * @param cSignatureKnowledgeSecretKeyBytes Encrypted KEY_SIGNATURE_KNOWLEDGE key.
      * @param salt Salt that was used for encryption.
      * @param keyGenerator Key generator instance.
      * @return Original KEY_SIGNATURE_KNOWLEDGE key.
-     * @throws InvalidKeyException In case invalid key is provided
-     * @throws IllegalBlockSizeException In case invalid key is provided
-     * @throws BadPaddingException In case invalid padding is provided
+     * @throws InvalidKeyException In case invalid key is provided.
+     * @throws CryptoProviderException In case cryptography provider is initialized incorrectly.
+     * @throws GenericCryptoException In case any other cryptography error occurs.
      */
-    public static SecretKey getSignatureKnowledgeKey(char[] password, byte[] cSignatureKnoweldgeSecretKeyBytes, byte[] salt, KeyGenerator keyGenerator) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+    public static SecretKey getSignatureKnowledgeKey(char[] password, byte[] cSignatureKnowledgeSecretKeyBytes, byte[] salt, KeyGenerator keyGenerator) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         // Ask for the password and generate storage key
         SecretKey encryptionSignatureKnowledgeKey = keyGenerator.deriveSecretKeyFromPassword(new String(password), salt);
 
         // Encrypt the knowledge related key using the password derived key
         AESEncryptionUtils aes = new AESEncryptionUtils();
         byte[] iv = new byte[16];
-        byte[] signatureKnowledgeSecretKeyBytes = aes.decrypt(cSignatureKnoweldgeSecretKeyBytes, iv, encryptionSignatureKnowledgeKey, "AES/CBC/NoPadding");
+        byte[] signatureKnowledgeSecretKeyBytes = aes.decrypt(cSignatureKnowledgeSecretKeyBytes, iv, encryptionSignatureKnowledgeKey, "AES/CBC/NoPadding");
         return PowerAuthConfiguration.INSTANCE.getKeyConvertor().convertBytesToSharedSecretKey(signatureKnowledgeSecretKeyBytes);
     }
 


### PR DESCRIPTION
This pull request migrates error handling to new exceptions from powerauth-crypto, which are thrown instead of returning null values.