### PR TITLE
Fix #28: Invalid message in auto-commit mode for custom activation

### DIFF
--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/CreateActivationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/CreateActivationStep.java
@@ -335,7 +335,7 @@ public class CreateActivationStep implements BaseStep {
                     if (stepLogger != null) {
                         stepLogger.writeItem(
                                 "Activation Done",
-                                "Public key exchange was successfully completed, commit the activation on server",
+                                "Public key exchange was successfully completed, commit the activation on server if required",
                                 "OK",
                                 objectMap
                         );


### PR DESCRIPTION
Unfortunately we do not know in the client whether auto-commit mode is enabled, so at least I updated the message text.