### PR TITLE
Fix #50: Crypto 3.0: Encrypt step

### DIFF
--- a/powerauth-java-cmd-lib/pom.xml
+++ b/powerauth-java-cmd-lib/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.6</version>
+            <version>2.9.7</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/model/EncryptStepModel.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/model/EncryptStepModel.java
@@ -31,6 +31,7 @@ public class EncryptStepModel extends BaseStepModel {
     private String applicationKey;
     private String applicationSecret;
     private PublicKey masterPublicKey;
+    private String scope;
 
     /**
      * Set name of file with request data.
@@ -96,6 +97,34 @@ public class EncryptStepModel extends BaseStepModel {
         this.masterPublicKey = masterPublicKey;
     }
 
+    /**
+     * Get ECIES encryption scope.
+     *
+     * <h5>PowerAuth protocol versions:</h5>
+     * <ul>
+     *     <li>3.0</li>
+     * </ul>
+     *
+     * @return ECIES encryption scope.
+     */
+    public String getScope() {
+        return scope;
+    }
+
+    /**
+     * Set ECIES encryption scope.
+     *
+     * <h5>PowerAuth protocol versions:</h5>
+     * <ul>
+     *     <li>3.0</li>
+     * </ul>
+     *
+     * @param scope ECIES encryption scope.
+     */
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
     @Override
     public Map<String, Object> toMap() {
         Map<String, Object> context = super.toMap();
@@ -103,6 +132,7 @@ public class EncryptStepModel extends BaseStepModel {
         context.put("APPLICATION_KEY", applicationKey);
         context.put("APPLICATION_SECRET", applicationSecret);
         context.put("MASTER_PUBLIC_KEY", masterPublicKey);
+        context.put("SCOPE", scope);
         return context;
     }
 
@@ -113,5 +143,6 @@ public class EncryptStepModel extends BaseStepModel {
         setApplicationKey((String) context.get("APPLICATION_KEY"));
         setApplicationSecret((String) context.get("APPLICATION_SECRET"));
         setMasterPublicKey((PublicKey) context.get("MASTER_PUBLIC_KEY"));
+        setScope((String) context.get("SCOPE"));
     }
 }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/CreateActivationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/CreateActivationStep.java
@@ -59,6 +59,7 @@ public class CreateActivationStep implements BaseStep {
     private static final ObjectMapper mapper = RestClientConfiguration.defaultMapper();
 
     @Override
+    @SuppressWarnings("unchecked")
     public JSONObject execute(StepLogger stepLogger, Map<String, Object> context) throws Exception {
         // Read properties from "context"
         CreateActivationStepModel model = new CreateActivationStepModel();

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/EncryptStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/EncryptStep.java
@@ -1,0 +1,228 @@
+/*
+ * PowerAuth Command-line utility
+ * Copyright 2018 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.cmd.steps.v3;
+
+import com.google.common.io.BaseEncoding;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEncryptor;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesFactory;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesCryptogram;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesSharedInfo1;
+import io.getlime.security.powerauth.http.PowerAuthEncryptionHttpHeader;
+import io.getlime.security.powerauth.lib.cmd.logging.StepLogger;
+import io.getlime.security.powerauth.lib.cmd.steps.BaseStep;
+import io.getlime.security.powerauth.lib.cmd.steps.model.EncryptStepModel;
+import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
+import io.getlime.security.powerauth.lib.cmd.util.JsonUtil;
+import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
+import io.getlime.security.powerauth.provider.CryptoProviderUtil;
+import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
+import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
+import org.json.simple.JSONObject;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.security.interfaces.ECPublicKey;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+
+/**
+ * Encrypt step encrypts request data using ECIES encryption in application or activation scope.
+ *
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *     <li>3.0</li>
+ * </ul>
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
+ */
+public class EncryptStep implements BaseStep {
+
+    private static final CryptoProviderUtil keyConversion = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
+    private static final EciesFactory eciesFactory = new EciesFactory();
+
+    /**
+     * Execute this step with given context.
+     * @param stepLogger Step logger.
+     * @param context Provided context.
+     * @return Result status object, null in case of failure.
+     * @throws Exception In case of any error.
+     */
+    @SuppressWarnings("unchecked")
+    public JSONObject execute(StepLogger stepLogger, Map<String, Object> context) throws Exception {
+
+        // Read properties from "context"
+        EncryptStepModel model = new EncryptStepModel();
+        model.fromMap(context);
+
+        if (stepLogger != null) {
+            stepLogger.writeItem(
+                    "Encrypt Request Started",
+                    null,
+                    "OK",
+                    null
+            );
+        }
+
+        // Prepare the encryption URI
+        String uri = model.getUriString();
+
+        // Read data which needs to be encrypted
+        File dataFile = new File(model.getDataFileName());
+        if (!dataFile.exists()) {
+            if (stepLogger != null) {
+                stepLogger.writeError("Encrypt Request Failed", "File not found: " + model.getDataFileName());
+                stepLogger.writeDoneFailed();
+            }
+            return null;
+        }
+
+        Scanner scanner = new Scanner(dataFile);
+        scanner.useDelimiter("\\Z");
+        String requestData = scanner.next();
+
+        if (stepLogger != null) {
+            stepLogger.writeItem(
+                    "Preparing Request Data",
+                    "Following data will be encrypted",
+                    "OK",
+                    requestData
+            );
+        }
+
+        final byte[] applicationSecret = model.getApplicationSecret().getBytes(StandardCharsets.UTF_8);
+        final EciesEncryptor encryptor;
+        // Prepare the encryption header
+        final PowerAuthEncryptionHttpHeader header;
+        switch (model.getScope()) {
+            case "application":
+                // Prepare ECIES encryptor with sharedInfo1 = /pa/generic/application
+                encryptor = eciesFactory.getEciesEncryptorForApplication((ECPublicKey) model.getMasterPublicKey(),
+                        applicationSecret, EciesSharedInfo1.APPLICATION_SCOPE_GENERIC);
+                header = new PowerAuthEncryptionHttpHeader(model.getApplicationKey(), model.getVersion());
+                break;
+
+            case "activation":
+                // Prepare ECIES encryptor with sharedInfo1 = /pa/generic/activation
+                final byte[] transportMasterKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "transportMasterKey"));
+                final byte[] serverPublicKeyBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "serverPublicKey"));
+                final ECPublicKey serverPublicKey = (ECPublicKey) keyConversion.convertBytesToPublicKey(serverPublicKeyBytes);
+                final String activationId = JsonUtil.stringValue(model.getResultStatusObject(), "activationId");
+                encryptor = eciesFactory.getEciesEncryptorForActivation(serverPublicKey, applicationSecret,
+                        transportMasterKeyBytes, EciesSharedInfo1.ACTIVATION_SCOPE_GENERIC);
+                header = new PowerAuthEncryptionHttpHeader(model.getApplicationKey(), activationId, model.getVersion());
+                break;
+
+            default:
+                if (stepLogger != null) {
+                    stepLogger.writeError("Encrypt Request Failed", "Unsupported encryption scope: " + model.getScope());
+                    stepLogger.writeDoneFailed();
+                }
+                return null;
+        }
+        String httpEncryptionHeader = header.buildHttpHeader();
+
+        // Prepare encrypted request
+        final EciesCryptogram eciesCryptogram = encryptor.encryptRequest(requestData.getBytes());
+        final EciesEncryptedRequest request = new EciesEncryptedRequest();
+        final String ephemeralPublicKeyBase64 = BaseEncoding.base64().encode(eciesCryptogram.getEphemeralPublicKey());
+        final String encryptedData = BaseEncoding.base64().encode(eciesCryptogram.getEncryptedData());
+        final String mac = BaseEncoding.base64().encode(eciesCryptogram.getMac());
+        request.setEphemeralPublicKey(ephemeralPublicKeyBase64);
+        request.setEncryptedData(encryptedData);
+        request.setMac(mac);
+
+        final byte[] requestBytes = RestClientConfiguration.defaultMapper().writeValueAsBytes(request);
+
+        if (stepLogger != null) {
+            stepLogger.writeItem(
+                    "Encrypting Request Data",
+                    "Following data is sent to intermediate server",
+                    "OK",
+                    request
+            );
+        }
+
+        try {
+
+            Map<String, String> headers = new HashMap<>();
+            headers.put("Accept", "application/json");
+            headers.put("Content-Type", "application/json");
+            headers.put(PowerAuthEncryptionHttpHeader.HEADER_NAME, httpEncryptionHeader);
+            headers.putAll(model.getHeaders());
+
+            HttpResponse response = Unirest.post(uri)
+                    .headers(headers)
+                    .body(requestBytes)
+                    .asString();
+
+            if (response.getStatus() == 200) {
+                EciesEncryptedResponse encryptedResponse = RestClientConfiguration
+                        .defaultMapper()
+                        .readValue(response.getRawBody(), EciesEncryptedResponse.class);
+
+                if (stepLogger != null) {
+                    stepLogger.writeServerCallOK(encryptedResponse, HttpUtil.flattenHttpHeaders(response.getHeaders()));
+                }
+
+                byte[] macResponse = BaseEncoding.base64().decode(encryptedResponse.getMac());
+                byte[] encryptedDataResponse = BaseEncoding.base64().decode(encryptedResponse.getEncryptedData());
+                EciesCryptogram eciesCryptogramResponse = new EciesCryptogram(macResponse, encryptedDataResponse);
+
+                final byte[] decryptedBytes = encryptor.decryptResponse(eciesCryptogramResponse);
+
+                String decryptedMessage = new String(decryptedBytes);
+                model.getResultStatusObject().put("responseData", decryptedMessage);
+
+                if (stepLogger != null) {
+                    stepLogger.writeItem(
+                            "Decrypted Response",
+                            "Following data were decrypted",
+                            "OK",
+                            decryptedMessage
+                    );
+                    stepLogger.writeDoneOK();
+                }
+                return model.getResultStatusObject();
+            } else {
+                if (stepLogger != null) {
+                    stepLogger.writeServerCallError(response.getStatus(), response.getBody(), HttpUtil.flattenHttpHeaders(response.getHeaders()));
+                    stepLogger.writeDoneFailed();
+                }
+                return null;
+            }
+        } catch (UnirestException exception) {
+            if (stepLogger != null) {
+                stepLogger.writeServerCallConnectionError(exception);
+                stepLogger.writeDoneFailed();
+            }
+            return null;
+        } catch (Exception exception) {
+            if (stepLogger != null) {
+                stepLogger.writeError(exception);
+                stepLogger.writeDoneFailed();
+            }
+            return null;
+        }
+    }
+
+}

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/SignAndEncryptStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/SignAndEncryptStep.java
@@ -151,7 +151,7 @@ public class SignAndEncryptStep implements BaseStep {
         // Generate nonce
         byte[] pa_nonce = keyGenerator.generateRandomBytes(16);
 
-        // Construct the signature base string data part based on HTTP method (GET requires different code).
+        // Construct the signature base string data
         byte[] dataFileBytes = VerifySignatureUtil.extractRequestDataBytes(model, stepLogger);
 
         // Compute the current PowerAuth signature for possession and knowledge factor

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/SignAndEncryptStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/SignAndEncryptStep.java
@@ -14,57 +14,65 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.getlime.security.powerauth.lib.cmd.steps;
+package io.getlime.security.powerauth.lib.cmd.steps.v3;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.BaseEncoding;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
-import io.getlime.core.rest.model.base.response.Response;
 import io.getlime.security.powerauth.crypto.client.keyfactory.PowerAuthClientKeyFactory;
 import io.getlime.security.powerauth.crypto.client.signature.PowerAuthClientSignature;
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEncryptor;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesFactory;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesCryptogram;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesSharedInfo1;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
 import io.getlime.security.powerauth.http.PowerAuthHttpBody;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.lib.cmd.logging.StepLogger;
+import io.getlime.security.powerauth.lib.cmd.steps.BaseStep;
 import io.getlime.security.powerauth.lib.cmd.steps.model.VerifySignatureStepModel;
 import io.getlime.security.powerauth.lib.cmd.util.*;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
+import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
+import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
 import org.json.simple.JSONObject;
 
 import javax.crypto.SecretKey;
+import java.io.File;
 import java.io.FileWriter;
 import java.nio.charset.StandardCharsets;
+import java.security.interfaces.ECPublicKey;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Scanner;
 
 /**
- * Helper class with signature verification logic.
+ * Sign and encrypt step signs request data and performs encryption using ECIES encryption in activation scope.
  *
  * <h5>PowerAuth protocol versions:</h5>
  * <ul>
- *     <li>2.0</li>
- *     <li>2.1</li>
  *     <li>3.0</li>
  * </ul>
  *
- * @author Petr Dvorak
+ * @author Roman Strobl, roman.strobl@wultra.com
  *
  */
-public class VerifySignatureStep implements BaseStep {
+public class SignAndEncryptStep implements BaseStep {
 
     private static final CryptoProviderUtil keyConversion = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
     private static final KeyGenerator keyGenerator = new KeyGenerator();
     private static final PowerAuthClientSignature signature = new PowerAuthClientSignature();
     private static final PowerAuthClientKeyFactory keyFactory = new PowerAuthClientKeyFactory();
     private static final ObjectMapper mapper = RestClientConfiguration.defaultMapper();
+    private static final EciesFactory eciesFactory = new EciesFactory();
 
     /**
-     * Execute this step with given context
-     * @param context Provided context
+     * Execute this step with given context.
+     * @param stepLogger Step logger.
+     * @param context Provided context.
      * @return Result status object, null in case of failure.
      * @throws Exception In case of any error.
      */
@@ -77,10 +85,51 @@ public class VerifySignatureStep implements BaseStep {
 
         if (stepLogger != null) {
             stepLogger.writeItem(
-                    "Signature Validation Started",
+                    "Sign and Encrypt Request Started",
                     null,
                     "OK",
                     null
+            );
+        }
+
+        // Read data which needs to be encrypted
+        File dataFile = new File(model.getDataFileName());
+        if (!dataFile.exists()) {
+            if (stepLogger != null) {
+                stepLogger.writeError("Sign and Encrypt Request Failed", "File not found: " + model.getDataFileName());
+                stepLogger.writeDoneFailed();
+            }
+            return null;
+        }
+
+        // Verify that HTTP method is set
+        if (model.getHttpMethod() == null) {
+            if (stepLogger != null) {
+                stepLogger.writeError("HTTP method not specified", "Specify HTTP method to use for sending request");
+                stepLogger.writeDoneFailed();
+            }
+            return null;
+        }
+
+        // Verify HTTP method, only POST is supported
+        if (!"POST".equals(model.getHttpMethod().toUpperCase())) {
+            if (stepLogger != null) {
+                stepLogger.writeError("Sign and Encrypt Request Failed", "Unsupported HTTP method: "+model.getHttpMethod().toUpperCase());
+                stepLogger.writeDoneFailed();
+            }
+            return null;
+        }
+
+        Scanner scanner = new Scanner(dataFile);
+        scanner.useDelimiter("\\Z");
+        String requestData = scanner.next();
+
+        if (stepLogger != null) {
+            stepLogger.writeItem(
+                    "Preparing Request Data",
+                    "Following data will be encrypted",
+                    "OK",
+                    requestData
             );
         }
 
@@ -92,7 +141,6 @@ public class VerifySignatureStep implements BaseStep {
         byte[] signatureKnowledgeKeySalt = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureKnowledgeKeySalt"));
         byte[] signatureKnowledgeKeyEncryptedBytes = BaseEncoding.base64().decode(JsonUtil.stringValue(model.getResultStatusObject(), "signatureKnowledgeKeyEncrypted"));
 
-        // Get password to unlock the knowledge factor key
         char[] password = VerifySignatureUtil.getKnowledgeKeyPassword(model);
 
         // Get the signature keys
@@ -113,7 +161,25 @@ public class VerifySignatureStep implements BaseStep {
         final PowerAuthSignatureHttpHeader header = new PowerAuthSignatureHttpHeader(activationId, model.getApplicationKey(), pa_signature, model.getSignatureType().toString(), BaseEncoding.base64().encode(pa_nonce), model.getVersion());
         String httpAuthorizationHeader = header.buildHttpHeader();
 
+        // Increment the counter
+        CounterUtil.incrementCounter(model);
 
+        // Store the activation status (updated counter)
+        String formatted = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(model.getResultStatusObject());
+        try (FileWriter file = new FileWriter(model.getStatusFileName())) {
+            file.write(formatted);
+        }
+
+        final String transportKeyBase64 = JsonUtil.stringValue(model.getResultStatusObject(), "transportMasterKey");
+        final String serverPublicKeyBase64 = JsonUtil.stringValue(model.getResultStatusObject(), "serverPublicKey");
+
+        // Prepare ECIES encryptor with sharedInfo1 = /pa/generic/activation
+        final byte[] applicationSecret = model.getApplicationSecret().getBytes(StandardCharsets.UTF_8);
+        final byte[] transportMasterKeyBytes = BaseEncoding.base64().decode(transportKeyBase64);
+        final byte[] serverPublicKeyBytes = BaseEncoding.base64().decode(serverPublicKeyBase64);
+        final ECPublicKey serverPublicKey = (ECPublicKey) keyConversion.convertBytesToPublicKey(serverPublicKeyBytes);
+        final EciesEncryptor encryptor = eciesFactory.getEciesEncryptorForActivation(serverPublicKey, applicationSecret,
+                        transportMasterKeyBytes, EciesSharedInfo1.ACTIVATION_SCOPE_GENERIC);
 
         if (stepLogger != null) {
 
@@ -126,26 +192,40 @@ public class VerifySignatureStep implements BaseStep {
             lowLevelData.put("signatureBaseString", signatureBaseString);
             lowLevelData.put("resourceId", model.getResourceId());
             lowLevelData.put("nonce", BaseEncoding.base64().encode(pa_nonce));
+            lowLevelData.put("applicationKey", model.getApplicationKey());
             lowLevelData.put("applicationSecret", model.getApplicationSecret());
+            lowLevelData.put("transportKey", transportKeyBase64);
+            lowLevelData.put("serverPublicKey", serverPublicKeyBase64);
+            lowLevelData.put("activationId", activationId);
 
             stepLogger.writeItem(
                     "Signature Calculation Parameters",
-                    "Low level cryptographic inputs required to compute signature - mainly a signature base string and a counter value.",
+                    "Low level cryptographic inputs required to compute signature and keys used for data encryption.",
                     "OK",
                     lowLevelData
             );
         }
 
-        // Increment the counter
-        CounterUtil.incrementCounter(model);
+        // Prepare encrypted request
+        final EciesCryptogram eciesCryptogram = encryptor.encryptRequest(requestData.getBytes());
+        final EciesEncryptedRequest request = new EciesEncryptedRequest();
+        final String ephemeralPublicKeyBase64 = BaseEncoding.base64().encode(eciesCryptogram.getEphemeralPublicKey());
+        final String encryptedData = BaseEncoding.base64().encode(eciesCryptogram.getEncryptedData());
+        final String mac = BaseEncoding.base64().encode(eciesCryptogram.getMac());
+        request.setEphemeralPublicKey(ephemeralPublicKeyBase64);
+        request.setEncryptedData(encryptedData);
+        request.setMac(mac);
 
-        // Store the activation status (updated counter)
-        String formatted = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(model.getResultStatusObject());
-        try (FileWriter file = new FileWriter(model.getStatusFileName())) {
-            file.write(formatted);
+        final byte[] requestBytes = RestClientConfiguration.defaultMapper().writeValueAsBytes(request);
+
+        if (stepLogger != null) {
+            stepLogger.writeItem(
+                    "Encrypting Request Data",
+                    "Following data is sent to intermediate server",
+                    "OK",
+                    request
+            );
         }
-
-        // Call the server with activation data
         try {
 
             Map<String, String> headers = new HashMap<>();
@@ -158,36 +238,36 @@ public class VerifySignatureStep implements BaseStep {
                 stepLogger.writeServerCall(model.getUriString(), model.getHttpMethod().toUpperCase(), new String(dataFileBytes, StandardCharsets.UTF_8), headers);
             }
 
-            HttpResponse response;
-            if ("GET".equals(model.getHttpMethod().toUpperCase())) {
-                response = Unirest.get(model.getUriString())
+            HttpResponse response = Unirest.post(model.getUriString())
                         .headers(headers)
+                        .body(requestBytes)
                         .asString();
-            } else {
-                response = Unirest.post(model.getUriString())
-                        .headers(headers)
-                        .body(dataFileBytes)
-                        .asString();
-            }
 
             if (response.getStatus() == 200) {
-                TypeReference<Response> typeReference = new TypeReference<Response>() {};
-                Response responseWrapper = RestClientConfiguration
+                EciesEncryptedResponse encryptedResponse = RestClientConfiguration
                         .defaultMapper()
-                        .readValue(response.getRawBody(), typeReference);
+                        .readValue(response.getRawBody(), EciesEncryptedResponse.class);
 
                 if (stepLogger != null) {
-                    stepLogger.writeServerCallOK(responseWrapper, HttpUtil.flattenHttpHeaders(response.getHeaders()));
+                    stepLogger.writeServerCallOK(encryptedResponse, HttpUtil.flattenHttpHeaders(response.getHeaders()));
+                }
 
-                    // Print the results
+                byte[] macResponse = BaseEncoding.base64().decode(encryptedResponse.getMac());
+                byte[] encryptedDataResponse = BaseEncoding.base64().decode(encryptedResponse.getEncryptedData());
+                EciesCryptogram eciesCryptogramResponse = new EciesCryptogram(macResponse, encryptedDataResponse);
+
+                final byte[] decryptedBytes = encryptor.decryptResponse(eciesCryptogramResponse);
+
+                String decryptedMessage = new String(decryptedBytes);
+                model.getResultStatusObject().put("responseData", decryptedMessage);
+
+                if (stepLogger != null) {
                     stepLogger.writeItem(
-                            "Signature verified",
-                            "Activation signature was verified successfully",
+                            "Decrypted Response",
+                            "Following data were decrypted",
                             "OK",
-                            null
-
+                            decryptedMessage
                     );
-
                     stepLogger.writeDoneOK();
                 }
                 return model.getResultStatusObject();

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/VerifySignatureUtil.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/VerifySignatureUtil.java
@@ -1,0 +1,98 @@
+package io.getlime.security.powerauth.lib.cmd.util;
+
+import com.google.common.io.BaseEncoding;
+import io.getlime.security.powerauth.http.PowerAuthRequestCanonizationUtils;
+import io.getlime.security.powerauth.lib.cmd.logging.StepLogger;
+import io.getlime.security.powerauth.lib.cmd.steps.model.VerifySignatureStepModel;
+
+import java.io.Console;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class VerifySignatureUtil {
+
+    /**
+     * Extract request data bytes for signature verification.
+     *
+     * @param model Verify signature step model.
+     * @param stepLogger Step logger.
+     * @return Request data bytes.
+     * @throws URISyntaxException In case URI is invalid.
+     * @throws IOException In case of any IO error.
+     */
+    public static byte[] extractRequestDataBytes(VerifySignatureStepModel model, StepLogger stepLogger) throws URISyntaxException, IOException {
+        byte[] dataFileBytes;
+        if ("GET".equals(model.getHttpMethod().toUpperCase())) {
+            String query = new URI(model.getUriString()).getRawQuery();
+            String canonizedQuery = PowerAuthRequestCanonizationUtils.canonizeGetParameters(query);
+            if (canonizedQuery != null) {
+                dataFileBytes = canonizedQuery.getBytes(StandardCharsets.UTF_8);
+                if (stepLogger != null) {
+                    stepLogger.writeItem(
+                            "Normalized GET data",
+                            "GET query data were normalized into the canonical string.",
+                            "OK",
+                            canonizedQuery
+                    );
+                }
+            } else {
+                dataFileBytes = new byte[0];
+                if (stepLogger != null) {
+                    stepLogger.writeItem(
+                            "Empty data",
+                            "No GET query parameters found in provided URL, signature will contain no data",
+                            "WARNING",
+                            null
+                    );
+                }
+            }
+        } else {
+            // Read data input file
+            if (model.getDataFileName() != null && Files.exists(Paths.get(model.getDataFileName()))) {
+                dataFileBytes = Files.readAllBytes(Paths.get(model.getDataFileName()));
+                if (stepLogger != null) {
+                    stepLogger.writeItem(
+                            "Request payload",
+                            "Data from the request payload file, used as the POST / DELETE / ... method body, encoded as Base64.",
+                            "OK",
+                            BaseEncoding.base64().encode(dataFileBytes)
+                    );
+                }
+            } else {
+                dataFileBytes = new byte[0];
+                if (stepLogger != null) {
+                    stepLogger.writeItem(
+                            "Empty data",
+                            "Data file was not found, signature will contain no data",
+                            "WARNING",
+                            null
+                    );
+                }
+            }
+        }
+        return dataFileBytes;
+    }
+
+    /**
+     * Get knowledge key unlock password.
+     *
+     * @param model Verify signature step model.
+     * @return Knowledge key unlock password.
+     */
+    public static char[] getKnowledgeKeyPassword(VerifySignatureStepModel model) {
+        char[] password;
+        if (model.getPassword() == null) {
+            // Ask for the password to unlock knowledge factor key
+            Console console = System.console();
+            password = console.readPassword("Enter your password to unlock the knowledge related key: ");
+        } else {
+            // Password is stored in model
+            password = model.getPassword().toCharArray();
+        }
+        return password;
+    }
+}

--- a/powerauth-java-cmd/pom.xml
+++ b/powerauth-java-cmd/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.0.4.RELEASE</version>
+                <version>2.0.7.RELEASE</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
This pull request adds ECIES support to `powerauth-cmd-tool` when using non-PowerAuth endpoints.

Changes:
- Encrypt step
- Sign and encrypt step
- Common verify signature logic moved to utility class
- Updated project dependencies
- Minor code cleanup
