### PR TITLE
Fix #85: Use UTF-8 encoding when reading data files

### DIFF
--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/EncryptStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v2/EncryptStep.java
@@ -89,7 +89,7 @@ public class EncryptStep implements BaseStep {
             return null;
         }
 
-        Scanner scanner = new Scanner(dataFile);
+        Scanner scanner = new Scanner(dataFile, "UTF-8");
         scanner.useDelimiter("\\Z");
         String requestData = "";
         if (scanner.hasNext()) {

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/EncryptStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/EncryptStep.java
@@ -96,7 +96,7 @@ public class EncryptStep implements BaseStep {
             return null;
         }
 
-        Scanner scanner = new Scanner(dataFile);
+        Scanner scanner = new Scanner(dataFile, "UTF-8");
         scanner.useDelimiter("\\Z");
         String requestData = "";
         if (scanner.hasNext()) {

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/SignAndEncryptStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/SignAndEncryptStep.java
@@ -120,7 +120,7 @@ public class SignAndEncryptStep implements BaseStep {
             return null;
         }
 
-        Scanner scanner = new Scanner(dataFile);
+        Scanner scanner = new Scanner(dataFile, "UTF-8");
         scanner.useDelimiter("\\Z");
         String requestData = "";
         if (scanner.hasNext()) {


### PR DESCRIPTION
This was done so that encryption of `byte[]` works when non-standard characters are used.