### PR TITLE
Fix #140: Add application platform during activation

### DIFF
--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/model/ActivationRecoveryStepModel.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/model/ActivationRecoveryStepModel.java
@@ -30,6 +30,7 @@ public class ActivationRecoveryStepModel extends BaseStepModel {
     private Map<String, Object> customAttributes;
     private String statusFileName;
     private String activationName;
+    private String deviceInfo;
     private String applicationKey;
     private String applicationSecret;
     private String password;
@@ -107,6 +108,22 @@ public class ActivationRecoveryStepModel extends BaseStepModel {
     }
 
     /**
+     * Get information about user device.
+     * @return Information about user device.
+     */
+    public String getDeviceInfo() {
+        return deviceInfo;
+    }
+
+    /**
+     * Set information about user device.
+     * @param deviceInfo Information about user device.
+     */
+    public void setDeviceInfo(String deviceInfo) {
+        this.deviceInfo = deviceInfo;
+    }
+
+    /**
      * Get application key.
      * @return Application key.
      */
@@ -179,6 +196,7 @@ public class ActivationRecoveryStepModel extends BaseStepModel {
         context.put("STATUS_FILENAME", statusFileName);
         context.put("PASSWORD", password);
         context.put("ACTIVATION_NAME", activationName);
+        context.put("DEVICE_INFO", deviceInfo);
         context.put("APPLICATION_KEY", applicationKey);
         context.put("APPLICATION_SECRET", applicationSecret);
         return context;
@@ -194,6 +212,7 @@ public class ActivationRecoveryStepModel extends BaseStepModel {
         setStatusFileName((String) context.get("STATUS_FILENAME"));
         setPassword((String) context.get("PASSWORD"));
         setActivationName((String) context.get("ACTIVATION_NAME"));
+        setDeviceInfo((String) context.get("DEVICE_INFO"));
         setApplicationKey((String) context.get("APPLICATION_KEY"));
         setApplicationSecret((String) context.get("APPLICATION_SECRET"));
     }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/model/ActivationRecoveryStepModel.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/model/ActivationRecoveryStepModel.java
@@ -30,6 +30,7 @@ public class ActivationRecoveryStepModel extends BaseStepModel {
     private Map<String, Object> customAttributes;
     private String statusFileName;
     private String activationName;
+    private String platform;
     private String deviceInfo;
     private String applicationKey;
     private String applicationSecret;
@@ -105,6 +106,22 @@ public class ActivationRecoveryStepModel extends BaseStepModel {
      */
     public void setActivationName(String activationName) {
         this.activationName = activationName;
+    }
+
+    /**
+     * Get user device platform.
+     * @return User device platform.
+     */
+    public String getPlatform() {
+        return platform;
+    }
+
+    /**
+     * Set user device platform.
+     * @param platform User device platform.
+     */
+    public void setPlatform(String platform) {
+        this.platform = platform;
     }
 
     /**
@@ -196,6 +213,7 @@ public class ActivationRecoveryStepModel extends BaseStepModel {
         context.put("STATUS_FILENAME", statusFileName);
         context.put("PASSWORD", password);
         context.put("ACTIVATION_NAME", activationName);
+        context.put("PLATFORM", platform);
         context.put("DEVICE_INFO", deviceInfo);
         context.put("APPLICATION_KEY", applicationKey);
         context.put("APPLICATION_SECRET", applicationSecret);
@@ -212,6 +230,7 @@ public class ActivationRecoveryStepModel extends BaseStepModel {
         setStatusFileName((String) context.get("STATUS_FILENAME"));
         setPassword((String) context.get("PASSWORD"));
         setActivationName((String) context.get("ACTIVATION_NAME"));
+        setPlatform((String) context.get("PLATFORM"));
         setDeviceInfo((String) context.get("DEVICE_INFO"));
         setApplicationKey((String) context.get("APPLICATION_KEY"));
         setApplicationSecret((String) context.get("APPLICATION_SECRET"));

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/model/CreateActivationStepModel.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/model/CreateActivationStepModel.java
@@ -31,6 +31,7 @@ public class CreateActivationStepModel extends BaseStepModel {
     private String statusFileName;
     private String activationOtp;
     private String activationName;
+    private String deviceInfo;
     private String applicationKey;
     private String applicationSecret;
     private String password;
@@ -81,6 +82,14 @@ public class CreateActivationStepModel extends BaseStepModel {
         this.activationName = activationName;
     }
 
+    public String getDeviceInfo() {
+        return deviceInfo;
+    }
+
+    public void setDeviceInfo(String deviceInfo) {
+        this.deviceInfo = deviceInfo;
+    }
+
     public String getApplicationKey() {
         return applicationKey;
     }
@@ -123,6 +132,7 @@ public class CreateActivationStepModel extends BaseStepModel {
         context.put("STATUS_FILENAME", statusFileName);
         context.put("PASSWORD", password);
         context.put("ACTIVATION_NAME", activationName);
+        context.put("DEVICE_INFO", deviceInfo);
         context.put("APPLICATION_KEY", applicationKey);
         context.put("APPLICATION_SECRET", applicationSecret);
         return context;
@@ -139,6 +149,7 @@ public class CreateActivationStepModel extends BaseStepModel {
         setStatusFileName((String) context.get("STATUS_FILENAME"));
         setPassword((String) context.get("PASSWORD"));
         setActivationName((String) context.get("ACTIVATION_NAME"));
+        setDeviceInfo((String) context.get("DEVICE_INFO"));
         setApplicationKey((String) context.get("APPLICATION_KEY"));
         setApplicationSecret((String) context.get("APPLICATION_SECRET"));
     }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/model/CreateActivationStepModel.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/model/CreateActivationStepModel.java
@@ -31,6 +31,7 @@ public class CreateActivationStepModel extends BaseStepModel {
     private String statusFileName;
     private String activationOtp;
     private String activationName;
+    private String platform;
     private String deviceInfo;
     private String applicationKey;
     private String applicationSecret;
@@ -80,6 +81,14 @@ public class CreateActivationStepModel extends BaseStepModel {
 
     public void setActivationName(String activationName) {
         this.activationName = activationName;
+    }
+
+    public String getPlatform() {
+        return platform;
+    }
+
+    public void setPlatform(String platform) {
+        this.platform = platform;
     }
 
     public String getDeviceInfo() {
@@ -132,6 +141,7 @@ public class CreateActivationStepModel extends BaseStepModel {
         context.put("STATUS_FILENAME", statusFileName);
         context.put("PASSWORD", password);
         context.put("ACTIVATION_NAME", activationName);
+        context.put("PLATFORM", platform);
         context.put("DEVICE_INFO", deviceInfo);
         context.put("APPLICATION_KEY", applicationKey);
         context.put("APPLICATION_SECRET", applicationSecret);
@@ -149,6 +159,7 @@ public class CreateActivationStepModel extends BaseStepModel {
         setStatusFileName((String) context.get("STATUS_FILENAME"));
         setPassword((String) context.get("PASSWORD"));
         setActivationName((String) context.get("ACTIVATION_NAME"));
+        setPlatform((String) context.get("PLATFORM"));
         setDeviceInfo((String) context.get("DEVICE_INFO"));
         setApplicationKey((String) context.get("APPLICATION_KEY"));
         setApplicationSecret((String) context.get("APPLICATION_SECRET"));

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/model/PrepareActivationStepModel.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/model/PrepareActivationStepModel.java
@@ -29,6 +29,7 @@ public class PrepareActivationStepModel extends BaseStepModel {
     private String statusFileName;
     private String activationCode;
     private String activationName;
+    private String platform;
     private String deviceInfo;
     private String applicationKey;
     private String applicationSecret;
@@ -57,6 +58,14 @@ public class PrepareActivationStepModel extends BaseStepModel {
      */
     public void setActivationName(String activationName) {
         this.activationName = activationName;
+    }
+
+    /**
+     * Set user device platform.
+     * @param platform User device platform.
+     */
+    public void setPlatform(String platform) {
+        this.platform = platform;
     }
 
     /**
@@ -111,6 +120,10 @@ public class PrepareActivationStepModel extends BaseStepModel {
         return activationName;
     }
 
+    public String getPlatform() {
+        return platform;
+    }
+
     public String getDeviceInfo() {
         return deviceInfo;
     }
@@ -139,6 +152,7 @@ public class PrepareActivationStepModel extends BaseStepModel {
         context.put("ACTIVATION_CODE", activationCode);
         context.put("PASSWORD", password);
         context.put("ACTIVATION_NAME", activationName);
+        context.put("PLATFORM", platform);
         context.put("DEVICE_INFO", deviceInfo);
         context.put("APPLICATION_KEY", applicationKey);
         context.put("APPLICATION_SECRET", applicationSecret);
@@ -153,6 +167,7 @@ public class PrepareActivationStepModel extends BaseStepModel {
         setActivationCode((String) context.get("ACTIVATION_CODE"));
         setPassword((String) context.get("PASSWORD"));
         setActivationName((String) context.get("ACTIVATION_NAME"));
+        setPlatform((String) context.get("PLATFORM"));
         setDeviceInfo((String) context.get("DEVICE_INFO"));
         setApplicationKey((String) context.get("APPLICATION_KEY"));
         setApplicationSecret((String) context.get("APPLICATION_SECRET"));

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/model/PrepareActivationStepModel.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/model/PrepareActivationStepModel.java
@@ -29,6 +29,7 @@ public class PrepareActivationStepModel extends BaseStepModel {
     private String statusFileName;
     private String activationCode;
     private String activationName;
+    private String deviceInfo;
     private String applicationKey;
     private String applicationSecret;
     private String password;
@@ -56,6 +57,14 @@ public class PrepareActivationStepModel extends BaseStepModel {
      */
     public void setActivationName(String activationName) {
         this.activationName = activationName;
+    }
+
+    /**
+     * Set information about user device.
+     * @param deviceInfo Information about user device.
+     */
+    public void setDeviceInfo(String deviceInfo) {
+        this.deviceInfo = deviceInfo;
     }
 
     /**
@@ -102,6 +111,10 @@ public class PrepareActivationStepModel extends BaseStepModel {
         return activationName;
     }
 
+    public String getDeviceInfo() {
+        return deviceInfo;
+    }
+
     public String getApplicationKey() {
         return applicationKey;
     }
@@ -126,6 +139,7 @@ public class PrepareActivationStepModel extends BaseStepModel {
         context.put("ACTIVATION_CODE", activationCode);
         context.put("PASSWORD", password);
         context.put("ACTIVATION_NAME", activationName);
+        context.put("DEVICE_INFO", deviceInfo);
         context.put("APPLICATION_KEY", applicationKey);
         context.put("APPLICATION_SECRET", applicationSecret);
         return context;
@@ -139,6 +153,7 @@ public class PrepareActivationStepModel extends BaseStepModel {
         setActivationCode((String) context.get("ACTIVATION_CODE"));
         setPassword((String) context.get("PASSWORD"));
         setActivationName((String) context.get("ACTIVATION_NAME"));
+        setDeviceInfo((String) context.get("DEVICE_INFO"));
         setApplicationKey((String) context.get("APPLICATION_KEY"));
         setApplicationSecret((String) context.get("APPLICATION_SECRET"));
     }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/ActivationRecoveryStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/ActivationRecoveryStep.java
@@ -37,6 +37,7 @@ import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
 import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
 import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
 import io.getlime.security.powerauth.rest.api.model.entity.ActivationType;
+import io.getlime.security.powerauth.rest.api.model.entity.Platform;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer2Request;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
@@ -130,6 +131,8 @@ public class ActivationRecoveryStep implements BaseStep {
         ActivationLayer2Request requestL2 = new ActivationLayer2Request();
         requestL2.setActivationName(model.getActivationName());
         requestL2.setDevicePublicKey(devicePublicKeyBase64);
+        requestL2.setPlatform(Platform.UNKNOWN);
+        requestL2.setDeviceInfo(model.getDeviceInfo());
 
         // Encrypt request data using ECIES in application scope with sharedInfo1 = /pa/activation
         final boolean useIv = !"3.0".equals(model.getVersion());

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/ActivationRecoveryStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/ActivationRecoveryStep.java
@@ -37,7 +37,6 @@ import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
 import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
 import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
 import io.getlime.security.powerauth.rest.api.model.entity.ActivationType;
-import io.getlime.security.powerauth.rest.api.model.entity.Platform;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer2Request;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
@@ -131,7 +130,7 @@ public class ActivationRecoveryStep implements BaseStep {
         ActivationLayer2Request requestL2 = new ActivationLayer2Request();
         requestL2.setActivationName(model.getActivationName());
         requestL2.setDevicePublicKey(devicePublicKeyBase64);
-        requestL2.setPlatform(Platform.UNKNOWN);
+        requestL2.setPlatform(model.getPlatform());
         requestL2.setDeviceInfo(model.getDeviceInfo());
 
         // Encrypt request data using ECIES in application scope with sharedInfo1 = /pa/activation

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CreateActivationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CreateActivationStep.java
@@ -37,6 +37,7 @@ import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
 import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
 import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
 import io.getlime.security.powerauth.rest.api.model.entity.ActivationType;
+import io.getlime.security.powerauth.rest.api.model.entity.Platform;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer2Request;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
@@ -130,6 +131,8 @@ public class CreateActivationStep implements BaseStep {
         ActivationLayer2Request requestL2 = new ActivationLayer2Request();
         requestL2.setActivationName(model.getActivationName());
         requestL2.setDevicePublicKey(devicePublicKeyBase64);
+        requestL2.setPlatform(Platform.UNKNOWN);
+        requestL2.setDeviceInfo(model.getDeviceInfo());
 
         // Encrypt request data using ECIES in application scope with sharedInfo1 = /pa/activation
         final boolean useIv = !"3.0".equals(model.getVersion());

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CreateActivationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CreateActivationStep.java
@@ -37,7 +37,6 @@ import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
 import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
 import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
 import io.getlime.security.powerauth.rest.api.model.entity.ActivationType;
-import io.getlime.security.powerauth.rest.api.model.entity.Platform;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer2Request;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
@@ -131,7 +130,7 @@ public class CreateActivationStep implements BaseStep {
         ActivationLayer2Request requestL2 = new ActivationLayer2Request();
         requestL2.setActivationName(model.getActivationName());
         requestL2.setDevicePublicKey(devicePublicKeyBase64);
-        requestL2.setPlatform(Platform.UNKNOWN);
+        requestL2.setPlatform(model.getPlatform());
         requestL2.setDeviceInfo(model.getDeviceInfo());
 
         // Encrypt request data using ECIES in application scope with sharedInfo1 = /pa/activation

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/PrepareActivationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/PrepareActivationStep.java
@@ -38,7 +38,6 @@ import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
 import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
 import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
 import io.getlime.security.powerauth.rest.api.model.entity.ActivationType;
-import io.getlime.security.powerauth.rest.api.model.entity.Platform;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer2Request;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
@@ -143,7 +142,7 @@ public class PrepareActivationStep implements BaseStep {
         ActivationLayer2Request requestL2 = new ActivationLayer2Request();
         requestL2.setActivationName(model.getActivationName());
         requestL2.setDevicePublicKey(devicePublicKeyBase64);
-        requestL2.setPlatform(Platform.UNKNOWN);
+        requestL2.setPlatform(model.getPlatform());
         requestL2.setDeviceInfo(model.getDeviceInfo());
 
         // Encrypt request data using ECIES in application scope with sharedInfo1 = /pa/activation

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/PrepareActivationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/PrepareActivationStep.java
@@ -38,6 +38,7 @@ import io.getlime.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
 import io.getlime.security.powerauth.lib.cmd.util.HttpUtil;
 import io.getlime.security.powerauth.lib.cmd.util.RestClientConfiguration;
 import io.getlime.security.powerauth.rest.api.model.entity.ActivationType;
+import io.getlime.security.powerauth.rest.api.model.entity.Platform;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer2Request;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
@@ -142,6 +143,8 @@ public class PrepareActivationStep implements BaseStep {
         ActivationLayer2Request requestL2 = new ActivationLayer2Request();
         requestL2.setActivationName(model.getActivationName());
         requestL2.setDevicePublicKey(devicePublicKeyBase64);
+        requestL2.setPlatform(Platform.UNKNOWN);
+        requestL2.setDeviceInfo(model.getDeviceInfo());
 
         // Encrypt request data using ECIES in application scope with sharedInfo1 = /pa/activation
         final boolean useIv = !"3.0".equals(model.getVersion());

--- a/powerauth-java-cmd/src/main/java/io/getlime/security/powerauth/app/cmd/Application.java
+++ b/powerauth-java-cmd/src/main/java/io/getlime/security/powerauth/app/cmd/Application.java
@@ -97,6 +97,7 @@ public class Application {
             options.addOption("r", "reason", true, "Reason why vault is being unlocked.");
             options.addOption("o", "scope", true, "ECIES encryption scope: 'application' or 'activation'.");
             options.addOption("R", "recovery-code", true, "Recovery code to be confirmed.");
+            options.addOption("P", "platform", true, "User device platform.");
             options.addOption("D", "device-info", true, "Information about user device.");
             options.addOption("v", "version", true, "PowerAuth protocol version.");
 
@@ -167,6 +168,13 @@ public class Application {
                     //
                 }
 
+            }
+
+            String platform;
+            if (cmd.hasOption("P")) {
+                platform = cmd.getOptionValue("P");
+            } else {
+                platform = "unknown";
             }
 
             String deviceInfo;
@@ -345,6 +353,7 @@ public class Application {
                     PrepareActivationStepModel model = new PrepareActivationStepModel();
                     model.setActivationCode(cmd.getOptionValue("a"));
                     model.setActivationName(ConfigurationUtil.getApplicationName(clientConfigObject));
+                    model.setPlatform(platform);
                     model.setDeviceInfo(deviceInfo);
                     model.setApplicationKey(ConfigurationUtil.getApplicationKey(clientConfigObject));
                     model.setApplicationSecret(ConfigurationUtil.getApplicationSecret(clientConfigObject));
@@ -575,6 +584,7 @@ public class Application {
 
                     CreateActivationStepModel model = new CreateActivationStepModel();
                     model.setActivationName(ConfigurationUtil.getApplicationName(clientConfigObject));
+                    model.setPlatform(platform);
                     model.setDeviceInfo(deviceInfo);
                     model.setActivationOtp(cmd.getOptionValue("a"));
                     model.setApplicationKey(ConfigurationUtil.getApplicationKey(clientConfigObject));
@@ -822,6 +832,7 @@ public class Application {
 
                     ActivationRecoveryStepModel model = new ActivationRecoveryStepModel();
                     model.setActivationName(ConfigurationUtil.getApplicationName(clientConfigObject));
+                    model.setPlatform(platform);
                     model.setDeviceInfo(deviceInfo);
                     model.setApplicationKey(ConfigurationUtil.getApplicationKey(clientConfigObject));
                     model.setApplicationSecret(ConfigurationUtil.getApplicationSecret(clientConfigObject));

--- a/powerauth-java-cmd/src/main/java/io/getlime/security/powerauth/app/cmd/Application.java
+++ b/powerauth-java-cmd/src/main/java/io/getlime/security/powerauth/app/cmd/Application.java
@@ -97,6 +97,7 @@ public class Application {
             options.addOption("r", "reason", true, "Reason why vault is being unlocked.");
             options.addOption("o", "scope", true, "ECIES encryption scope: 'application' or 'activation'.");
             options.addOption("R", "recovery-code", true, "Recovery code to be confirmed.");
+            options.addOption("D", "device-info", true, "Information about user device.");
             options.addOption("v", "version", true, "PowerAuth protocol version.");
 
             Option httpHeaderOption = Option.builder("H")
@@ -166,6 +167,13 @@ public class Application {
                     //
                 }
 
+            }
+
+            String deviceInfo;
+            if (cmd.hasOption("D")) {
+                deviceInfo = cmd.getOptionValue("D");
+            } else {
+                deviceInfo = "cmd-tool";
             }
 
             // Read values
@@ -337,6 +345,7 @@ public class Application {
                     PrepareActivationStepModel model = new PrepareActivationStepModel();
                     model.setActivationCode(cmd.getOptionValue("a"));
                     model.setActivationName(ConfigurationUtil.getApplicationName(clientConfigObject));
+                    model.setDeviceInfo(deviceInfo);
                     model.setApplicationKey(ConfigurationUtil.getApplicationKey(clientConfigObject));
                     model.setApplicationSecret(ConfigurationUtil.getApplicationSecret(clientConfigObject));
                     model.setHeaders(httpHeaders);
@@ -566,6 +575,7 @@ public class Application {
 
                     CreateActivationStepModel model = new CreateActivationStepModel();
                     model.setActivationName(ConfigurationUtil.getApplicationName(clientConfigObject));
+                    model.setDeviceInfo(deviceInfo);
                     model.setActivationOtp(cmd.getOptionValue("a"));
                     model.setApplicationKey(ConfigurationUtil.getApplicationKey(clientConfigObject));
                     model.setApplicationSecret(ConfigurationUtil.getApplicationSecret(clientConfigObject));
@@ -812,6 +822,7 @@ public class Application {
 
                     ActivationRecoveryStepModel model = new ActivationRecoveryStepModel();
                     model.setActivationName(ConfigurationUtil.getApplicationName(clientConfigObject));
+                    model.setDeviceInfo(deviceInfo);
                     model.setApplicationKey(ConfigurationUtil.getApplicationKey(clientConfigObject));
                     model.setApplicationSecret(ConfigurationUtil.getApplicationSecret(clientConfigObject));
                     model.setIdentityAttributes(identityAttributes);


### PR DESCRIPTION
For command line tool the platform is `UNKNOWN`, the device info is `cmd-tool` by default and user can also override it.