### PR TITLE
Keep decrypted response payload in the step context

### DIFF
--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/AbstractBaseStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/AbstractBaseStep.java
@@ -212,6 +212,7 @@ public abstract class AbstractBaseStep<M extends BaseStepData, R> implements Bas
         EciesEncryptedResponse encryptedResponse = stepContext.getResponseContext().getResponseBodyObject();
         byte[] decryptedBytes = SecurityUtil.decryptBytesFromResponse(encryptor, encryptedResponse);
         final T responsePayload = RestClientConfiguration.defaultMapper().readValue(decryptedBytes, cls);
+        stepContext.getResponseContext().setResponsePayloadDecrypted(responsePayload);
 
         stepContext.getStepLogger().writeItem(
                 getStep().id() + "-response-decrypt",

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/context/ResponseContext.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/context/ResponseContext.java
@@ -23,4 +23,9 @@ public class ResponseContext<R> {
      */
     private ResponseEntity<R> responseEntity;
 
+    /**
+     * HTTP response payload (decrypted from the response entity)
+     */
+    private Object responsePayloadDecrypted;
+
 }


### PR DESCRIPTION
- Decryption of the payload from response entity is allowed only once
- The response context will hold the decrypted payload object