### PR TITLE
Fix #223: Exclude log4j-api dependency

### DIFF
--- a/powerauth-java-cmd-lib/pom.xml
+++ b/powerauth-java-cmd-lib/pom.xml
@@ -69,6 +69,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
             <version>2.6.1</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/powerauth-java-cmd/pom.xml
+++ b/powerauth-java-cmd/pom.xml
@@ -40,6 +40,12 @@
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-java-cmd-lib</artifactId>
             <version>1.2.0-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
This change should resolve any future questions about the Log4J dependencies included in Spring logging.