### PR TITLE
Fix #320: Nonce and ephemeral public key are ignored in protocol V3.1 responses

### DIFF
--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/consts/PowerAuthVersion.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/consts/PowerAuthVersion.java
@@ -104,6 +104,16 @@ public enum PowerAuthVersion {
     }
 
     /**
+     * Provides flag whether decryption uses different non-zero initialization vector.
+     * <p>This feature is supported only for protocol V3.2+.</p>
+     *
+     * @return Flag whether decryption uses different non-zero initialization vector.
+     */
+    public boolean useDifferentIvForResponse() {
+        return majorVersion >= 3 && V3_2.equals(this);
+    }
+
+    /**
      * Provides flag whether encryption uses timestamp.
      * <p>This feature is supported only for protocol V3.2+.</p>
      *

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/SecurityUtil.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/SecurityUtil.java
@@ -87,34 +87,6 @@ public class SecurityUtil {
     }
 
     /**
-     * Creates new decryptor
-     *
-     * @param applicationSecretValue Application secret value
-     * @param resultStatusObject Activation status object
-     * @param envelopeKey Envelope key
-     * @param ephemeralPublicKey Ephemeral public key
-     *
-     * @return New decryptor instance
-     * @throws CryptoProviderException when an error during encryptor preparation occurred
-     * @throws GenericCryptoException when an error during encryptor preparation occurred
-     */
-    public static EciesDecryptor createDecryptor(String applicationSecretValue,
-                                                 ResultStatusObject resultStatusObject,
-                                                 EciesEnvelopeKey envelopeKey,
-                                                 byte[] ephemeralPublicKey,
-                                                 PowerAuthVersion version,
-                                                 byte[] associatedData)
-            throws CryptoProviderException, GenericCryptoException {
-        final byte[] applicationSecret = applicationSecretValue.getBytes(StandardCharsets.UTF_8);
-        final byte[] transportMasterKeyBytes = Base64.getDecoder().decode(resultStatusObject.getTransportMasterKey());
-        final Long timestamp = version.useTimestamp() ? new Date().getTime() : null;
-        final byte[] nonceBytes = version.useIv() ? new KeyGenerator().generateRandomBytes(16) : null;
-        final EciesParameters parameters = EciesParameters.builder().nonce(nonceBytes).associatedData(associatedData).timestamp(timestamp).build();
-        return ECIES_FACTORY.getEciesDecryptor(EciesScope.ACTIVATION_SCOPE, envelopeKey, applicationSecret,
-                transportMasterKeyBytes, parameters, ephemeralPublicKey);
-    }
-
-    /**
      * Encrypts an object using the provided encryptor
      * <p>The object will be serialized to json and the json bytes will be then encrypted</p>
      *


### PR DESCRIPTION
This PR changes how cmd-tool library perform encryption for older protocol versions. Basically, we don't trust the server that nonce and ephemeral public key returned in response object should be used for the response decryption.

In `SecurityUtil.java` I have removed unused function for decryptor construction.