### PR TITLE
Fix #325: Use general encryptor

### DIFF
--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/header/EncryptionHeaderProvider.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/header/EncryptionHeaderProvider.java
@@ -20,7 +20,6 @@ import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorScope;
 import io.getlime.security.powerauth.http.PowerAuthEncryptionHttpHeader;
 import io.getlime.security.powerauth.lib.cmd.steps.context.RequestContext;
 import io.getlime.security.powerauth.lib.cmd.steps.context.StepContext;
-import io.getlime.security.powerauth.lib.cmd.steps.context.security.SecurityContext;
 import io.getlime.security.powerauth.lib.cmd.steps.model.data.EncryptionHeaderData;
 
 /**
@@ -39,8 +38,7 @@ public class EncryptionHeaderProvider implements PowerAuthHeaderProvider<Encrypt
         EncryptionHeaderData model = stepContext.getModel();
         EncryptorScope encryptorScope = stepContext.getSecurityContext().getEncryptorScope();
         if (encryptorScope == null) {
-            // Scope is not determined yet. To fix this, move call to "addHeader()" after "addEncryptedRequest" call.
-            throw new IllegalStateException("Scope of encryption is not yet determined");
+            throw new IllegalStateException("Scope is not determined yet. To fix this, move call to addHeader() after addEncryptedRequest call.");
         }
         String activationId = encryptorScope == EncryptorScope.ACTIVATION_SCOPE ? model.getResultStatus().getActivationId() : null;
         PowerAuthEncryptionHttpHeader header = new PowerAuthEncryptionHttpHeader(model.getApplicationKey(), activationId, model.getVersion().value());

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/AbstractBaseStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/AbstractBaseStep.java
@@ -208,22 +208,18 @@ public abstract class AbstractBaseStep<M extends BaseStepData, R> implements Bas
      */
     public void addEncryptedRequest(StepContext<M, R> stepContext, String applicationKey, String applicationSecret, EncryptorId encryptorId, byte[] data) throws Exception {
         M model = stepContext.getModel();
-        SimpleSecurityContext securityContext = (SimpleSecurityContext) stepContext.getSecurityContext();
-        ResultStatusObject resultStatusObject = model.getResultStatus();
+        final SimpleSecurityContext securityContext = (SimpleSecurityContext) stepContext.getSecurityContext();
+        final ResultStatusObject resultStatusObject = model.getResultStatus();
 
-        ClientEncryptor encryptor;
+        final ClientEncryptor encryptor;
         if (securityContext == null) {
             final byte[] transportMasterKeyBytes = Base64.getDecoder().decode(resultStatusObject.getTransportMasterKey());
-            encryptor = ENCRYPTOR_FACTORY.getClientEncryptor(
-                    encryptorId,
-                    new EncryptorParameters(model.getVersion().value(),applicationKey, resultStatusObject.getActivationId()),
-                    new ClientEncryptorSecrets(resultStatusObject.getServerPublicKeyObject(), applicationSecret, transportMasterKeyBytes)
-            );
-            stepContext.setSecurityContext(
-                    SimpleSecurityContext.builder()
+            final EncryptorParameters encryptorParameters = new EncryptorParameters(model.getVersion().value(), applicationKey, resultStatusObject.getActivationId());
+            final ClientEncryptorSecrets encryptorSecrets = new ClientEncryptorSecrets(resultStatusObject.getServerPublicKeyObject(), applicationSecret, transportMasterKeyBytes);
+            encryptor = ENCRYPTOR_FACTORY.getClientEncryptor(encryptorId, encryptorParameters, encryptorSecrets);
+            stepContext.setSecurityContext(SimpleSecurityContext.builder()
                             .encryptor(encryptor)
-                            .build()
-            );
+                            .build());
         } else {
             encryptor = securityContext.getEncryptor();
         }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/AbstractBaseStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/AbstractBaseStep.java
@@ -1,17 +1,34 @@
+/*
+ * PowerAuth Command-line utility
+ * Copyright 2023 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.getlime.security.powerauth.lib.cmd.steps;
 
 import com.google.common.collect.ImmutableList;
 import com.wultra.core.rest.client.base.RestClient;
 import com.wultra.core.rest.client.base.RestClientException;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesDecryptor;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEncryptor;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesFactory;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesParameters;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesPayload;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesScope;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesSharedInfo1;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
+import io.getlime.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.v3.ClientEncryptorSecrets;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
-import io.getlime.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
+import io.getlime.security.powerauth.crypto.lib.util.KeyConvertor;
 import io.getlime.security.powerauth.lib.cmd.consts.PowerAuthStep;
 import io.getlime.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import io.getlime.security.powerauth.lib.cmd.logging.DisabledStepLogger;
@@ -40,7 +57,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import javax.annotation.Nullable;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 /**
@@ -76,8 +92,9 @@ public abstract class AbstractBaseStep<M extends BaseStepData, R> implements Bas
      */
     protected final StepLoggerFactory stepLoggerFactory;
 
-    private static final EciesFactory ECIES_FACTORY = new EciesFactory();
+    private static final EncryptorFactory ENCRYPTOR_FACTORY = new EncryptorFactory();
     private static final KeyGenerator KEY_GENERATOR = new KeyGenerator();
+    private static final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
 
     /**
      * Constructor
@@ -179,44 +196,65 @@ public abstract class AbstractBaseStep<M extends BaseStepData, R> implements Bas
     }
 
     /**
-     * Prepares ECIES encryptor and encrypts request data with sharedInfo1.
+     * Prepares encryptor and encrypts request data with given encryptor.
      * The encrypted request is then added to the request context of this step.
      *
      * @param stepContext       Context of this step
+     * @param applicationKey    Application key.
      * @param applicationSecret Application secret
-     * @param eciesSharedInfo   Parameter sharedInfo1
+     * @param encryptorId       Encryptor identifier
      * @param data              Request data for the encryption
-     * @param associatedData    Data associated with ECIES
      * @throws Exception when an error during encryption of the request data occurred
      */
-    public void addEncryptedRequest(StepContext<M, R> stepContext, String applicationSecret, EciesSharedInfo1 eciesSharedInfo, byte[] data, byte[] associatedData) throws Exception {
+    public void addEncryptedRequest(StepContext<M, R> stepContext, String applicationKey, String applicationSecret, EncryptorId encryptorId, byte[] data) throws Exception {
         M model = stepContext.getModel();
         SimpleSecurityContext securityContext = (SimpleSecurityContext) stepContext.getSecurityContext();
         ResultStatusObject resultStatusObject = model.getResultStatus();
 
-        EciesEncryptor encryptor;
-        EciesParameters parameters;
+        ClientEncryptor encryptor;
         if (securityContext == null) {
-            parameters = getRequestEciesParameters(stepContext.getModel().getVersion(), associatedData);
-            encryptor = SecurityUtil.createEncryptorForActivationScope(applicationSecret, resultStatusObject, eciesSharedInfo, parameters);
+            final byte[] transportMasterKeyBytes = Base64.getDecoder().decode(resultStatusObject.getTransportMasterKey());
+            encryptor = ENCRYPTOR_FACTORY.getClientEncryptor(
+                    encryptorId,
+                    new EncryptorParameters(model.getVersion().value(),applicationKey, resultStatusObject.getActivationId()),
+                    new ClientEncryptorSecrets(resultStatusObject.getServerPublicKeyObject(), applicationSecret, transportMasterKeyBytes)
+            );
             stepContext.setSecurityContext(
                     SimpleSecurityContext.builder()
                             .encryptor(encryptor)
-                            .requestParameters(parameters)
                             .build()
             );
         } else {
             encryptor = securityContext.getEncryptor();
-            parameters = securityContext.getRequestParameters();
+        }
+        addEncryptedRequest(stepContext, encryptor, data);
+    }
+
+    /**
+     * Encrypts request data with given encryptor.
+     * The encrypted request is then added to the request context of this step.
+     *
+     * @param stepContext       Context of this step
+     * @param encryptor         Encryptor to use
+     * @param data              Request data for the encryption
+     * @throws Exception when an error during encryption of the request data occurred
+     */
+    public void addEncryptedRequest(StepContext<M, R> stepContext, ClientEncryptor encryptor, byte[] data) throws Exception {
+        M model = stepContext.getModel();
+        SimpleSecurityContext securityContext = (SimpleSecurityContext) stepContext.getSecurityContext();
+        if (securityContext == null) {
+            stepContext.setSecurityContext(
+                    SimpleSecurityContext.builder()
+                            .encryptor(encryptor)
+                            .build()
+            );
+        } else if (securityContext.getEncryptor() != encryptor) {
+            throw new Exception("Different encryptor is already set to security context");
         }
 
-        final boolean useIv = model.getVersion().useIv();
-        final boolean useTimestamp = model.getVersion().useTimestamp();
-
-        final EciesPayload eciesPayload = encryptor.encrypt(data, parameters);
-        final EciesEncryptedRequest encryptedRequest = SecurityUtil.createEncryptedRequest(eciesPayload);
-
-        stepContext.getRequestContext().setRequestObject(encryptedRequest);
+        final EncryptedRequest encryptedRequest = encryptor.encryptRequest(data);
+        final EciesEncryptedRequest requestObject = SecurityUtil.createEncryptedRequest(encryptedRequest);
+        stepContext.getRequestContext().setRequestObject(requestObject);
     }
 
     /**
@@ -225,39 +263,18 @@ public abstract class AbstractBaseStep<M extends BaseStepData, R> implements Bas
      * @param stepContext       Step context
      * @param cls               Class type of the decrypted object
      * @param <T>               Class of the decrypted object
-     * @param eciesScope        Scope of ECIES
-     * @param associatedData    Data associated with ECIES
      * @return Decrypted object from the provided response
-     * @throws Exception when an error during object decryption occurred
      */
-    public <T> T decryptResponse(StepContext<?, EciesEncryptedResponse> stepContext, Class<T> cls, EciesScope eciesScope, byte[] associatedData) throws Exception {
+    public <T> T decryptResponse(StepContext<?, EciesEncryptedResponse> stepContext, Class<T> cls) {
         try {
-            final PowerAuthVersion version = stepContext.getModel().getVersion();
             final SimpleSecurityContext securityContext = (SimpleSecurityContext) stepContext.getSecurityContext();
-            EciesEncryptedResponse encryptedResponse = stepContext.getResponseContext().getResponseBodyObject();
-            final byte[] transportMasterKeyBytes = Base64.getDecoder().decode(stepContext.getModel().getResultStatus().getTransportMasterKey());
-            final byte[] nonceBytes = version.useDifferentIvForResponse() && encryptedResponse.getNonce() != null ? Base64.getDecoder().decode(encryptedResponse.getNonce()) : securityContext.getRequestParameters().getNonce();
-            final Long timestamp = version.useTimestamp() ? encryptedResponse.getTimestamp() : null;
-            EciesParameters eciesParameters = EciesParameters.builder()
-                    .nonce(nonceBytes)
-                    .timestamp(timestamp)
-                    .build();
-            String applicationSecret = (String) stepContext.getModel().toMap().get("APPLICATION_SECRET");
-            byte[] ephemeralPublicKey = securityContext.getEncryptor().getEnvelopeKey().getEphemeralKeyPublic();
-            EciesEncryptor encryptor = securityContext.getEncryptor();
-            EciesDecryptor eciesDecryptor;
-            if (eciesScope == EciesScope.ACTIVATION_SCOPE) {
-                eciesDecryptor = ECIES_FACTORY.getEciesDecryptor(EciesScope.ACTIVATION_SCOPE,
-                        encryptor.getEnvelopeKey(), applicationSecret.getBytes(StandardCharsets.UTF_8), transportMasterKeyBytes,
-                        eciesParameters, ephemeralPublicKey);
-            } else {
-                eciesDecryptor = ECIES_FACTORY.getEciesDecryptor(EciesScope.APPLICATION_SCOPE,
-                        encryptor.getEnvelopeKey(), applicationSecret.getBytes(StandardCharsets.UTF_8), null,
-                        eciesParameters, ephemeralPublicKey);
-            }
-
-            byte[] decryptedBytes = SecurityUtil.decryptBytesFromResponse(eciesDecryptor, encryptedResponse, eciesParameters);
-
+            final EciesEncryptedResponse encryptedResponse = stepContext.getResponseContext().getResponseBodyObject();
+            final byte[] decryptedBytes = securityContext.getEncryptor().decryptResponse(new EncryptedResponse(
+                    encryptedResponse.getEncryptedData(),
+                    encryptedResponse.getMac(),
+                    encryptedResponse.getNonce(),
+                    encryptedResponse.getTimestamp()
+            ));
             final T responsePayload = RestClientConfiguration.defaultMapper().readValue(decryptedBytes, cls);
             stepContext.getResponseContext().setResponsePayloadDecrypted(responsePayload);
 
@@ -274,19 +291,6 @@ public abstract class AbstractBaseStep<M extends BaseStepData, R> implements Bas
             logger.debug(ex.getMessage(), ex);
             return null;
         }
-    }
-
-    /**
-     * Create EciesParameters object for the new encrypted request.
-     * @param version Protocol version.
-     * @param associatedData Associated data to be a part of the request.
-     * @return EciesParameters object.
-     * @throws CryptoProviderException In case of random generator fails.
-     */
-    public EciesParameters getRequestEciesParameters(PowerAuthVersion version, byte[] associatedData) throws CryptoProviderException {
-        final Long timestamp = version.useTimestamp() ? new Date().getTime() : null;
-        final byte[] nonceBytes = version.useIv() ? KEY_GENERATOR.generateRandomBytes(16) : null;
-        return EciesParameters.builder().nonce(nonceBytes).associatedData(associatedData).timestamp(timestamp).build();
     }
 
     /**

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/VerifySignatureStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/VerifySignatureStep.java
@@ -44,6 +44,7 @@ import java.util.Map;
  *     <li>2.1</li>
  *     <li>3.0</li>
  *     <li>3.1</li>
+ *     <li>3.2</li>
  * </ul>
  *
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/VerifyTokenStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/VerifyTokenStep.java
@@ -43,6 +43,7 @@ import java.util.Map;
  *     <li>2.1</li>
  *     <li>3.0</li>
  *     <li>3.1</li>
+ *     <li>3.2</li>
  * </ul>
  *
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/context/security/ActivationSecurityContext.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/context/security/ActivationSecurityContext.java
@@ -16,10 +16,8 @@
  */
 package io.getlime.security.powerauth.lib.cmd.steps.context.security;
 
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesDecryptor;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEncryptor;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesParameters;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesPayload;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorScope;
 import lombok.Builder;
 import lombok.Data;
 
@@ -37,25 +35,20 @@ public class ActivationSecurityContext implements SecurityContext {
     /**
      * Encryptor used on layer 1
      */
-    private EciesEncryptor encryptorL1;
+    private ClientEncryptor encryptorL1;
 
     /**
      * Encryptor used on layer 2
      */
-    private EciesEncryptor encryptorL2;
-
-    /**
-     * ECIES parameters used for request encryption on layer 1
-     */
-    private EciesParameters requestParametersL1;
-    /**
-     * ECIES parameters used for request encryption on layer 2
-     */
-    private EciesParameters requestParametersL2;
+    private ClientEncryptor encryptorL2;
 
     /**
      * Device key pair
      */
     private KeyPair deviceKeyPair;
 
+    @Override
+    public EncryptorScope getEncryptorScope() {
+        return EncryptorScope.APPLICATION_SCOPE;
+    }
 }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/context/security/SecurityContext.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/context/security/SecurityContext.java
@@ -16,11 +16,17 @@
  */
 package io.getlime.security.powerauth.lib.cmd.steps.context.security;
 
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorScope;
+
 /**
  * Security context interface
  *
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com
  */
 public interface SecurityContext {
-
+    /**
+     * Implementation must return scope of encryption to be used or null if scope is not determined yet.
+     * @return {@link EncryptorScope} or null if not known yet.
+     */
+    EncryptorScope getEncryptorScope();
 }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/context/security/SimpleSecurityContext.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/context/security/SimpleSecurityContext.java
@@ -16,8 +16,8 @@
  */
 package io.getlime.security.powerauth.lib.cmd.steps.context.security;
 
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEncryptor;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesParameters;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorScope;
 import lombok.Builder;
 import lombok.Data;
 
@@ -29,15 +29,13 @@ import lombok.Data;
 @Data
 @Builder
 public class SimpleSecurityContext implements SecurityContext {
-
     /**
      * Encryptor
      */
-    private EciesEncryptor encryptor;
+    private ClientEncryptor encryptor;
 
-    /**
-     * ECIES parameters used for request encryption
-     */
-    private EciesParameters requestParameters;
-
+    @Override
+    public EncryptorScope getEncryptorScope() {
+        return encryptor != null ? encryptor.getEncryptorId().scope() : null;
+    }
 }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/ActivationRecoveryStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/ActivationRecoveryStep.java
@@ -42,6 +42,7 @@ import java.util.Map;
  * <ul>
  *     <li>3.0</li>
  *     <li>3.1</li>
+ *     <li>3.2</li>
  * </ul>
  *
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com
@@ -90,8 +91,8 @@ public class ActivationRecoveryStep extends AbstractActivationStep<ActivationRec
 
         StepContext<ActivationRecoveryStepModel, EciesEncryptedResponse> stepContext = buildStepContext(stepLogger, model, requestContext);
 
+        addEncryptedRequest(stepContext);
         powerAuthHeaderFactory.getHeaderProvider(model).addHeader(stepContext);
-        addEncryptedRequest(stepContext, model.getVersion());
 
         return stepContext;
     }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CommitUpgradeStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CommitUpgradeStep.java
@@ -42,6 +42,7 @@ import java.util.Map;
  * <ul>
  *      <li>3.0</li>
  *      <li>3.1</li>
+ *      <li>3.2</li>
  * </ul>
  *
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/ConfirmRecoveryCodeStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/ConfirmRecoveryCodeStep.java
@@ -16,9 +16,7 @@
  */
 package io.getlime.security.powerauth.lib.cmd.steps.v3;
 
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesScope;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesSharedInfo1;
-import io.getlime.security.powerauth.crypto.lib.util.EciesUtils;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import io.getlime.security.powerauth.lib.cmd.consts.BackwardCompatibilityConst;
 import io.getlime.security.powerauth.lib.cmd.consts.PowerAuthConst;
 import io.getlime.security.powerauth.lib.cmd.consts.PowerAuthStep;
@@ -49,6 +47,7 @@ import java.util.Map;
  * <ul>
  *      <li>3.0</li>
  *      <li>3.1</li>
+ *      <li>3.2</li>
  * </ul>
  *
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com
@@ -111,9 +110,7 @@ public class ConfirmRecoveryCodeStep extends AbstractBaseStep<ConfirmRecoveryCod
         // Encrypt the request
         final byte[] requestBytesPayload = RestClientConfiguration.defaultMapper().writeValueAsBytes(confirmRequestPayload);
 
-        final String activationId = model.getResultStatus().getActivationId();
-        final byte[] associatedData = model.getVersion().useTimestamp() ? EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, model.getVersion().toString(), model.getApplicationKey(), activationId) : null;
-        addEncryptedRequest(stepContext, model.getApplicationSecret(), EciesSharedInfo1.CONFIRM_RECOVERY_CODE, requestBytesPayload, associatedData);
+        addEncryptedRequest(stepContext, model.getApplicationKey(), model.getApplicationSecret(), EncryptorId.CONFIRM_RECOVERY_CODE, requestBytesPayload);
 
         powerAuthHeaderFactory.getHeaderProvider(model).addHeader(stepContext);
 
@@ -124,11 +121,7 @@ public class ConfirmRecoveryCodeStep extends AbstractBaseStep<ConfirmRecoveryCod
 
     @Override
     public void processResponse(StepContext<ConfirmRecoveryCodeStepModel, EciesEncryptedResponse> stepContext) throws Exception {
-        final ConfirmRecoveryCodeStepModel model = stepContext.getModel();
-        final String activationId = model.getResultStatus().getActivationId();
-        final byte[] associatedData = model.getVersion().useTimestamp() ? EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, model.getVersion().toString(), model.getApplicationKey(), activationId) : null;
-        final ConfirmRecoveryResponsePayload confirmResponsePayload = decryptResponse(stepContext, ConfirmRecoveryResponsePayload.class, EciesScope.ACTIVATION_SCOPE, associatedData);
-
+        final ConfirmRecoveryResponsePayload confirmResponsePayload = decryptResponse(stepContext, ConfirmRecoveryResponsePayload.class);
         Map<String, Object> objectMap = new HashMap<>();
         objectMap.put("alreadyConfirmed", confirmResponsePayload.getAlreadyConfirmed());
 

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CreateActivationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CreateActivationStep.java
@@ -42,6 +42,7 @@ import java.util.Map;
  * <ul>
  *     <li>3.0</li>
  *     <li>3.1</li>
+ *     <li>3.2</li>
  * </ul>
  *
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com
@@ -91,8 +92,8 @@ public class CreateActivationStep extends AbstractActivationStep<CreateActivatio
         StepContext<CreateActivationStepModel, EciesEncryptedResponse> stepContext =
                 buildStepContext(stepLogger, model, requestContext);
 
+        addEncryptedRequest(stepContext);
         powerAuthHeaderFactory.getHeaderProvider(model).addHeader(stepContext);
-        addEncryptedRequest(stepContext, model.getVersion());
 
         return stepContext;
     }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CreateTokenStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/CreateTokenStep.java
@@ -17,9 +17,7 @@
 package io.getlime.security.powerauth.lib.cmd.steps.v3;
 
 import com.google.common.collect.ImmutableMap;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesScope;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesSharedInfo1;
-import io.getlime.security.powerauth.crypto.lib.util.EciesUtils;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import io.getlime.security.powerauth.lib.cmd.consts.BackwardCompatibilityConst;
 import io.getlime.security.powerauth.lib.cmd.consts.PowerAuthConst;
 import io.getlime.security.powerauth.lib.cmd.consts.PowerAuthStep;
@@ -47,6 +45,7 @@ import java.util.Map;
  * <ul>
  *      <li>3.0</li>
  *      <li>3.1</li>
+ *      <li>3.2</li>
  * </ul>
  *
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com
@@ -101,9 +100,7 @@ public class CreateTokenStep extends AbstractBaseStep<CreateTokenStepModel, Ecie
 
         StepContext<CreateTokenStepModel, EciesEncryptedResponse> stepContext = buildStepContext(stepLogger, model, requestContext);
 
-        final String activationId = model.getResultStatus().getActivationId();
-        final byte[] associatedData = model.getVersion().useTimestamp() ? EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, model.getVersion().toString(), model.getApplicationKey(), activationId) : null;
-        addEncryptedRequest(stepContext, model.getApplicationSecret(), EciesSharedInfo1.CREATE_TOKEN, PowerAuthConst.EMPTY_JSON_BYTES, associatedData);
+        addEncryptedRequest(stepContext, model.getApplicationKey(), model.getApplicationSecret(), EncryptorId.CREATE_TOKEN, PowerAuthConst.EMPTY_JSON_BYTES);
 
         powerAuthHeaderFactory.getHeaderProvider(model).addHeader(stepContext);
 
@@ -114,10 +111,8 @@ public class CreateTokenStep extends AbstractBaseStep<CreateTokenStepModel, Ecie
 
     @Override
     public void processResponse(StepContext<CreateTokenStepModel, EciesEncryptedResponse> stepContext) throws Exception {
-        final CreateTokenStepModel model = stepContext.getModel();
-        final String activationId = model.getResultStatus().getActivationId();
-        final byte[] associatedData = model.getVersion().useTimestamp() ? EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, model.getVersion().toString(), model.getApplicationKey(), activationId) : null;
-        final TokenResponsePayload tokenResponsePayload = decryptResponse(stepContext, TokenResponsePayload.class, EciesScope.ACTIVATION_SCOPE, associatedData);
+
+        final TokenResponsePayload tokenResponsePayload = decryptResponse(stepContext, TokenResponsePayload.class);
 
         stepContext.getStepLogger().writeItem(
                 getStep().id() + "-token-obtained",

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/EncryptStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/EncryptStep.java
@@ -124,11 +124,9 @@ public class EncryptStep extends AbstractBaseStep<EncryptStepModel, EciesEncrypt
             case "application" -> {
                 // Prepare ECIES encryptor with sharedInfo1 = /pa/generic/application
                 encryptorId = EncryptorId.APPLICATION_SCOPE_GENERIC;
-                encryptor = ENCRYPTOR_FACTORY.getClientEncryptor(
-                        encryptorId,
-                        new EncryptorParameters(model.getVersion().value(), model.getApplicationKey(), null),
-                        new ClientEncryptorSecrets(model.getMasterPublicKey(), model.getApplicationSecret())
-                );
+                final EncryptorParameters encryptorParameters = new EncryptorParameters(model.getVersion().value(), model.getApplicationKey(), null);
+                final ClientEncryptorSecrets encryptorSecrets = new ClientEncryptorSecrets(model.getMasterPublicKey(), model.getApplicationSecret());
+                encryptor = ENCRYPTOR_FACTORY.getClientEncryptor(encryptorId, encryptorParameters, encryptorSecrets);
                 header = new PowerAuthEncryptionHttpHeader(model.getApplicationKey(), model.getVersion().value());
             }
             case "activation" -> {

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/GetStatusStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/GetStatusStep.java
@@ -49,6 +49,7 @@ import java.util.Map;
  * <ul>
  *      <li>3.0</li>
  *      <li>3.1</li>
+ *      <li>3.2</li>
  * </ul>
  *
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/PrepareActivationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/PrepareActivationStep.java
@@ -46,6 +46,7 @@ import java.util.regex.Pattern;
  * <ul>
  *      <li>3.0</li>
  *      <li>3.1</li>
+ *      <li>3.2</li>
  * </ul>
  *
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com
@@ -115,8 +116,8 @@ public class PrepareActivationStep extends AbstractActivationStep<PrepareActivat
         StepContext<PrepareActivationStepModel, EciesEncryptedResponse> stepContext =
                 buildStepContext(stepLogger, model, requestContext);
 
+        addEncryptedRequest(stepContext);
         powerAuthHeaderFactory.getHeaderProvider(model).addHeader(stepContext);
-        addEncryptedRequest(stepContext, model.getVersion());
 
         return stepContext;
     }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/RemoveStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/RemoveStep.java
@@ -42,6 +42,7 @@ import java.util.Map;
  * <ul>
  *      <li>3.0</li>
  *      <li>3.1</li>
+ *      <li>3.2</li>
  * </ul>
  *
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/RemoveTokenStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/RemoveTokenStep.java
@@ -45,6 +45,7 @@ import java.util.Objects;
  * <ul>
  *      <li>3.0</li>
  *      <li>3.1</li>
+ *      <li>3.2</li>
  * </ul>
  *
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/SignAndEncryptStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/SignAndEncryptStep.java
@@ -16,9 +16,7 @@
  */
 package io.getlime.security.powerauth.lib.cmd.steps.v3;
 
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesScope;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesSharedInfo1;
-import io.getlime.security.powerauth.crypto.lib.util.EciesUtils;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import io.getlime.security.powerauth.lib.cmd.consts.BackwardCompatibilityConst;
 import io.getlime.security.powerauth.lib.cmd.consts.PowerAuthConst;
 import io.getlime.security.powerauth.lib.cmd.consts.PowerAuthStep;
@@ -48,6 +46,7 @@ import java.util.Map;
  * <ul>
  *     <li>3.0</li>
  *     <li>3.1</li>
+ *     <li>3.2</li>
  * </ul>
  *
  *  @author Lukas Lukovsky, lukas.lukovsky@wultra.com
@@ -140,9 +139,8 @@ public class SignAndEncryptStep extends AbstractBaseStep<VerifySignatureStepMode
         powerAuthHeaderFactory.getHeaderProvider(model).addHeader(stepContext);
 
         // Encrypt the request
-        final String activationId = model.getResultStatus().getActivationId();
-        final byte[] associatedData = EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, model.getVersion().toString(), model.getApplicationKey(), activationId);
-        addEncryptedRequest(stepContext, model.getApplicationSecret(), EciesSharedInfo1.ACTIVATION_SCOPE_GENERIC, requestDataBytes, associatedData);
+
+        addEncryptedRequest(stepContext, model.getApplicationKey(), model.getApplicationSecret(), EncryptorId.ACTIVATION_SCOPE_GENERIC, requestDataBytes);
 
         incrementCounter(model);
 
@@ -151,11 +149,7 @@ public class SignAndEncryptStep extends AbstractBaseStep<VerifySignatureStepMode
 
     @Override
     public void processResponse(StepContext<VerifySignatureStepModel, EciesEncryptedResponse> stepContext) throws Exception {
-        final VerifySignatureStepModel model = stepContext.getModel();
-        final String applicationSecret = model.getApplicationSecret();
-        final String activationId = model.getResultStatus().getActivationId();
-        final byte[] associatedData = EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, model.getVersion().toString(), model.getApplicationKey(), activationId);
-        SecurityUtil.processEncryptedResponse(stepContext, getStep().id(), applicationSecret, EciesScope.ACTIVATION_SCOPE, associatedData);
+        SecurityUtil.processEncryptedResponse(stepContext, getStep().id());
     }
 
 }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/StartUpgradeStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/StartUpgradeStep.java
@@ -16,9 +16,7 @@
 package io.getlime.security.powerauth.lib.cmd.steps.v3;
 
 import com.google.common.collect.ImmutableMap;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesScope;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesSharedInfo1;
-import io.getlime.security.powerauth.crypto.lib.util.EciesUtils;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import io.getlime.security.powerauth.lib.cmd.consts.BackwardCompatibilityConst;
 import io.getlime.security.powerauth.lib.cmd.consts.PowerAuthConst;
 import io.getlime.security.powerauth.lib.cmd.consts.PowerAuthStep;
@@ -46,6 +44,7 @@ import java.util.Map;
  * <ul>
  *      <li>3.0</li>
  *      <li>3.1</li>
+ *      <li>3.2</li>
  * </ul>
  *
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com
@@ -99,9 +98,7 @@ public class StartUpgradeStep extends AbstractBaseStep<StartUpgradeStepModel, Ec
         StepContext<StartUpgradeStepModel, EciesEncryptedResponse> stepContext =
                 buildStepContext(stepLogger, model, requestContext);
 
-        final String activationId = model.getResultStatus().getActivationId();
-        final byte[] associatedData = model.getVersion().useTimestamp() ? EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, model.getVersion().toString(), model.getApplicationKey(), activationId) : null;
-        addEncryptedRequest(stepContext, model.getApplicationSecret(), EciesSharedInfo1.UPGRADE, PowerAuthConst.EMPTY_JSON_BYTES, associatedData);
+        addEncryptedRequest(stepContext, model.getApplicationKey(), model.getApplicationSecret(), EncryptorId.UPGRADE, PowerAuthConst.EMPTY_JSON_BYTES);
 
         powerAuthHeaderFactory.getHeaderProvider(model).addHeader(stepContext);
 
@@ -111,9 +108,7 @@ public class StartUpgradeStep extends AbstractBaseStep<StartUpgradeStepModel, Ec
     @Override
     public void processResponse(StepContext<StartUpgradeStepModel, EciesEncryptedResponse> stepContext) throws Exception {
         final StartUpgradeStepModel model = stepContext.getModel();
-        final String activationId = model.getResultStatus().getActivationId();
-        final byte[] associatedData = model.getVersion().useTimestamp() ? EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, model.getVersion().toString(), model.getApplicationKey(), activationId) : null;
-        final UpgradeResponsePayload responsePayload = decryptResponse(stepContext, UpgradeResponsePayload.class, EciesScope.ACTIVATION_SCOPE, associatedData);
+        final UpgradeResponsePayload responsePayload = decryptResponse(stepContext, UpgradeResponsePayload.class);
 
         // Store the activation status (updated counter)
         model.getResultStatus().setCtrData(responsePayload.getCtrData());

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/TokenAndEncryptStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/TokenAndEncryptStep.java
@@ -16,9 +16,7 @@
  */
 package io.getlime.security.powerauth.lib.cmd.steps.v3;
 
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesScope;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesSharedInfo1;
-import io.getlime.security.powerauth.crypto.lib.util.EciesUtils;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import io.getlime.security.powerauth.lib.cmd.consts.BackwardCompatibilityConst;
 import io.getlime.security.powerauth.lib.cmd.consts.PowerAuthConst;
 import io.getlime.security.powerauth.lib.cmd.consts.PowerAuthStep;
@@ -47,6 +45,7 @@ import java.util.Map;
  * <ul>
  *     <li>3.0</li>
  *     <li>3.1</li>
+ *     <li>3.2</li>
  * </ul>
  *
  *  @author Roman Strobl, roman.strobl@wultra.com
@@ -137,23 +136,19 @@ public class TokenAndEncryptStep extends AbstractBaseStep<TokenAndEncryptStepMod
         );
 
         requestContext.setRequestObject(requestDataBytes);
-        powerAuthHeaderFactory.getHeaderProvider(model).addHeader(stepContext);
 
         // Encrypt the request
-        final String activationId = model.getResultStatus().getActivationId();
-        final byte[] associatedData = EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, model.getVersion().toString(), model.getApplicationKey(), activationId);
-        addEncryptedRequest(stepContext, model.getApplicationSecret(), EciesSharedInfo1.ACTIVATION_SCOPE_GENERIC, requestDataBytes, associatedData);
+
+        addEncryptedRequest(stepContext, model.getApplicationKey(), model.getApplicationSecret(), EncryptorId.ACTIVATION_SCOPE_GENERIC, requestDataBytes);
+
+        powerAuthHeaderFactory.getHeaderProvider(model).addHeader(stepContext);
 
         return stepContext;
     }
 
     @Override
     public void processResponse(StepContext<TokenAndEncryptStepModel, EciesEncryptedResponse> stepContext) throws Exception {
-        final TokenAndEncryptStepModel model = stepContext.getModel();
-        final String applicationSecret = model.getApplicationSecret();
-        final String activationId = model.getResultStatus().getActivationId();
-        final byte[] associatedData = EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, model.getVersion().toString(), model.getApplicationKey(), activationId);
-        SecurityUtil.processEncryptedResponse(stepContext, getStep().id(), applicationSecret, EciesScope.ACTIVATION_SCOPE, associatedData);
+        SecurityUtil.processEncryptedResponse(stepContext, getStep().id());
     }
 
 }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/VaultUnlockStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/VaultUnlockStep.java
@@ -17,9 +17,7 @@ package io.getlime.security.powerauth.lib.cmd.steps.v3;
 
 import io.getlime.security.powerauth.crypto.client.keyfactory.PowerAuthClientKeyFactory;
 import io.getlime.security.powerauth.crypto.client.vault.PowerAuthClientVault;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesScope;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesSharedInfo1;
-import io.getlime.security.powerauth.crypto.lib.util.EciesUtils;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import io.getlime.security.powerauth.crypto.lib.util.KeyConvertor;
 import io.getlime.security.powerauth.lib.cmd.consts.BackwardCompatibilityConst;
 import io.getlime.security.powerauth.lib.cmd.consts.PowerAuthConst;
@@ -56,6 +54,7 @@ import java.util.Map;
  * <ul>
  *      <li>3.0</li>
  *      <li>3.1</li>
+ *      <li>3.2</li>
  * </ul>
  *
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com
@@ -122,9 +121,7 @@ public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, Ecie
 
         final byte[] requestBytesPayload = RestClientConfiguration.defaultMapper().writeValueAsBytes(requestPayload);
 
-        final String activationId = model.getResultStatus().getActivationId();
-        final byte[] associatedData = model.getVersion().useTimestamp() ? EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, model.getVersion().toString(), model.getApplicationKey(), activationId) : null;
-        addEncryptedRequest(stepContext, model.getApplicationSecret(), EciesSharedInfo1.VAULT_UNLOCK, requestBytesPayload, associatedData);
+        addEncryptedRequest(stepContext, model.getApplicationKey(), model.getApplicationSecret(), EncryptorId.VAULT_UNLOCK, requestBytesPayload);
 
         powerAuthHeaderFactory.getHeaderProvider(model).addHeader(stepContext);
 
@@ -135,10 +132,7 @@ public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, Ecie
 
     @Override
     public void processResponse(StepContext<VaultUnlockStepModel, EciesEncryptedResponse> stepContext) throws Exception {
-        final VaultUnlockStepModel model = stepContext.getModel();
-        final String activationId = model.getResultStatus().getActivationId();
-        final byte[] associatedData = model.getVersion().useTimestamp() ? EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, model.getVersion().toString(), model.getApplicationKey(), activationId) : null;
-        final VaultUnlockResponsePayload responsePayload = decryptResponse(stepContext, VaultUnlockResponsePayload.class, EciesScope.ACTIVATION_SCOPE, associatedData);
+        final VaultUnlockResponsePayload responsePayload = decryptResponse(stepContext, VaultUnlockResponsePayload.class);
 
         ResultStatusObject resultStatusObject = stepContext.getModel().getResultStatus();
 

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/SecurityUtil.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/SecurityUtil.java
@@ -16,28 +16,19 @@
  */
 package io.getlime.security.powerauth.lib.cmd.util;
 
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesDecryptor;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEncryptor;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesFactory;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.exception.EciesException;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.*;
-import io.getlime.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
-import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
-import io.getlime.security.powerauth.crypto.lib.util.KeyConvertor;
-import io.getlime.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
+import io.getlime.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
 import io.getlime.security.powerauth.lib.cmd.steps.context.ResponseContext;
 import io.getlime.security.powerauth.lib.cmd.steps.context.StepContext;
 import io.getlime.security.powerauth.lib.cmd.steps.context.security.SimpleSecurityContext;
-import io.getlime.security.powerauth.lib.cmd.steps.pojo.ResultStatusObject;
 import io.getlime.security.powerauth.rest.api.model.request.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.response.EciesEncryptedResponse;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.security.interfaces.ECPublicKey;
-import java.security.spec.InvalidKeySpecException;
-import java.util.Base64;
 
 /**
  * Helper class with security utilities.
@@ -47,101 +38,36 @@ import java.util.Base64;
 public class SecurityUtil {
 
     /**
-     * ECIES factory
-     */
-    private static final EciesFactory ECIES_FACTORY = new EciesFactory();
-
-    /**
-     * Key convertor
-     */
-    private static final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
-
-    /**
-     * Creates new encryptor
-     *
-     * @param applicationSecretValue Application secret value
-     * @param resultStatusObject Activation status object
-     * @param sharedInfo Shared info parameter value
-     * @param parameters ECIES parameters.
-     *
-     * @return New encryptor instance
-     * @throws CryptoProviderException when an error during encryptor preparation occurred
-     * @throws GenericCryptoException when an error during encryptor preparation occurred
-     * @throws InvalidKeySpecException when an error during server public key processing occurred
-     * @throws EciesException when an encryption error occurs
-     */
-    public static EciesEncryptor createEncryptorForActivationScope(String applicationSecretValue,
-                                                                   ResultStatusObject resultStatusObject,
-                                                                   EciesSharedInfo1 sharedInfo,
-                                                                   EciesParameters parameters)
-            throws CryptoProviderException, GenericCryptoException, InvalidKeySpecException, EciesException {
-        final byte[] applicationSecret = applicationSecretValue.getBytes(StandardCharsets.UTF_8);
-        final byte[] serverPublicKeyBytes = Base64.getDecoder().decode(resultStatusObject.getServerPublicKey());
-        final byte[] transportMasterKeyBytes = Base64.getDecoder().decode(resultStatusObject.getTransportMasterKey());
-        final ECPublicKey serverPublicKey = (ECPublicKey) KEY_CONVERTOR.convertBytesToPublicKey(serverPublicKeyBytes);
-        return ECIES_FACTORY.getEciesEncryptorForActivation(serverPublicKey, applicationSecret,
-                transportMasterKeyBytes, sharedInfo, parameters);
-    }
-
-    /**
      * Encrypts an object using the provided encryptor
      * <p>The object will be serialized to json and the json bytes will be then encrypted</p>
      *
      * @param encryptor Encyptor instance
      * @param value Object value to be encrypted
-     * @param parameters ECIES parameters.
      * @return Cryptogram value of the provided object.
-     * @throws EciesException when an error during object encryption occurred
+     * @throws EncryptorException when an error during object encryption occurred
      * @throws IOException when an error during object encryption occurred
      */
-    public static EciesPayload encryptObject(EciesEncryptor encryptor, Object value, EciesParameters parameters)
-            throws EciesException, IOException {
+    public static EncryptedRequest encryptObject(ClientEncryptor encryptor, Object value)
+            throws EncryptorException, IOException {
         ByteArrayOutputStream baosL = new ByteArrayOutputStream();
         RestClientConfiguration.defaultMapper().writeValue(baosL, value);
-        return encryptor.encrypt(baosL.toByteArray(), parameters);
+        return encryptor.encryptRequest(baosL.toByteArray());
     }
 
-    /**
-     * Decrypts bytes from a response
-     *
-     * @param decryptor Decryptor
-     * @param encryptedResponse Encrypted response
-     * @param requestParameters ECIES parameters used to encrypt the request
-     * @return decrypted bytes
-     * @throws EciesException when an error during decryption occurred
-     */
-    public static byte[] decryptBytesFromResponse(EciesDecryptor decryptor, EciesEncryptedResponse encryptedResponse, EciesParameters requestParameters)
-            throws EciesException {
-
-        final byte[] ephemeralPublicKey = decryptor.getEnvelopeKey().getEphemeralKeyPublic();
-        final byte[] mac = Base64.getDecoder().decode(encryptedResponse.getMac());
-        final byte[] encryptedData = Base64.getDecoder().decode(encryptedResponse.getEncryptedData());
-        // TODO: we trust server here, to do not provide nonce in protocols 3.1 and older in response.
-        final byte[] nonce = encryptedResponse.getNonce() != null ? Base64.getDecoder().decode(encryptedResponse.getNonce()) : requestParameters.getNonce();
-        final Long timestamp = encryptedResponse.getTimestamp();
-        final EciesCryptogram eciesCryptogramResponse = new EciesCryptogram(ephemeralPublicKey, mac, encryptedData);
-
-        final EciesParameters responseParameters = new EciesParameters(nonce, requestParameters.getAssociatedData(), timestamp);
-        final EciesPayload payload = new EciesPayload(eciesCryptogramResponse, responseParameters);
-
-        return decryptor.decrypt(payload);
-    }
 
     /**
      * Creates an encrypted request instance
      *
-     * @param eciesPayload Ecies payload data to be sent
+     * @param encryptedRequest Ecies payload data to be sent
      * @return Encrypted request instance
      */
-    public static EciesEncryptedRequest createEncryptedRequest(EciesPayload eciesPayload) {
+    public static EciesEncryptedRequest createEncryptedRequest(EncryptedRequest encryptedRequest) {
         EciesEncryptedRequest request = new EciesEncryptedRequest();
-        final byte[] nonce = eciesPayload.getParameters().getNonce();
-        final Long timestamp = eciesPayload.getParameters().getTimestamp();
-        request.setEncryptedData(Base64.getEncoder().encodeToString(eciesPayload.getCryptogram().getEncryptedData()));
-        request.setEphemeralPublicKey(Base64.getEncoder().encodeToString(eciesPayload.getCryptogram().getEphemeralPublicKey()));
-        request.setMac(Base64.getEncoder().encodeToString(eciesPayload.getCryptogram().getMac()));
-        request.setNonce(nonce != null ? Base64.getEncoder().encodeToString(nonce) : null);
-        request.setTimestamp(timestamp);
+        request.setEncryptedData(encryptedRequest.getEncryptedData());
+        request.setEphemeralPublicKey(encryptedRequest.getEphemeralPublicKey());
+        request.setMac(encryptedRequest.getMac());
+        request.setNonce(encryptedRequest.getNonce());
+        request.setTimestamp(encryptedRequest.getTimestamp());
         return request;
     }
 
@@ -149,37 +75,19 @@ public class SecurityUtil {
      * Process an encrypted response for a step.
      * @param stepContext Step context.
      * @param stepId Step identifier.
-     * @param eciesScope Scope of ECIES.
-     * @param applicationSecret Application's secret.
-     * @param associatedData Associated data for ECIES.
      * @throws Exception Thrown in case response decryption fails.
      */
-    public static void processEncryptedResponse(StepContext<?, EciesEncryptedResponse> stepContext, String stepId, String applicationSecret, EciesScope eciesScope, byte[] associatedData) throws Exception {
+    public static void processEncryptedResponse(StepContext<?, EciesEncryptedResponse> stepContext, String stepId) throws Exception {
         ResponseContext<EciesEncryptedResponse> responseContext = stepContext.getResponseContext();
         SimpleSecurityContext securityContext = (SimpleSecurityContext) stepContext.getSecurityContext();
-        EciesEncryptor encryptor = securityContext.getEncryptor();
 
-        final PowerAuthVersion version = stepContext.getModel().getVersion();
-        final String nonce = responseContext.getResponseBodyObject().getNonce();
-        final byte[] nonceBytes = version.useDifferentIvForResponse() && nonce != null ? Base64.getDecoder().decode(nonce) : securityContext.getRequestParameters().getNonce();
-        final Long timestamp = responseContext.getResponseBodyObject().getTimestamp();
-        final byte[] ephemeralPublicKeyBytes = encryptor.getEnvelopeKey().getEphemeralKeyPublic();
-        final byte[] transportMasterKeyBytes = eciesScope == EciesScope.ACTIVATION_SCOPE ? Base64.getDecoder().decode(stepContext.getModel().getResultStatus().getTransportMasterKey()) : null;
-
-        EciesParameters eciesParameters = EciesParameters.builder().nonce(nonceBytes).timestamp(timestamp).associatedData(associatedData).build();
-
-        EciesDecryptor eciesDecryptor;
-        if (eciesScope == EciesScope.ACTIVATION_SCOPE) {
-            eciesDecryptor = ECIES_FACTORY.getEciesDecryptor(EciesScope.ACTIVATION_SCOPE,
-                    encryptor.getEnvelopeKey(), applicationSecret.getBytes(StandardCharsets.UTF_8), transportMasterKeyBytes,
-                    eciesParameters, ephemeralPublicKeyBytes);
-        } else {
-            eciesDecryptor = ECIES_FACTORY.getEciesDecryptor(EciesScope.APPLICATION_SCOPE,
-                    encryptor.getEnvelopeKey(), applicationSecret.getBytes(StandardCharsets.UTF_8), null,
-                    eciesParameters, ephemeralPublicKeyBytes);
-        }
-
-        final byte[] decryptedBytes = SecurityUtil.decryptBytesFromResponse(eciesDecryptor, responseContext.getResponseBodyObject(), eciesParameters);
+        EciesEncryptedResponse responseObject = responseContext.getResponseBodyObject();
+        final byte[] decryptedBytes = securityContext.getEncryptor().decryptResponse(new EncryptedResponse(
+                responseObject.getEncryptedData(),
+                responseObject.getMac(),
+                responseObject.getNonce(),
+                responseObject.getTimestamp()
+        ));
 
         String decryptedMessage = new String(decryptedBytes, StandardCharsets.UTF_8);
         stepContext.getModel().getResultStatus().setResponseData(decryptedMessage);


### PR DESCRIPTION
This PR replaces usage of low level `EciesEncryptor` and `EciesDecryptor` with new `ClientEncryptor` interface. There's also fix when in some cases library sent activation ID in application scoped encryption header.