### PR TITLE
Fix #411: Logging of steps create invalid JSON

### DIFF
--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/service/StepExecutionService.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/service/StepExecutionService.java
@@ -80,9 +80,9 @@ public class StepExecutionService {
             throw new PowerAuthCmdException();
         }
 
-        BaseStep step = stepProvider.getStep(stepId, version);
+        final BaseStep step = stepProvider.getStep(stepId, version);
 
-        ResultStatusObject result = step.execute(model.toMap());
+        final ResultStatusObject result = step.execute(stepLogger, model.toMap());
         if (result == null) {
             throw new PowerAuthCmdException();
         }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/AbstractBaseStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/AbstractBaseStep.java
@@ -126,26 +126,6 @@ public abstract class AbstractBaseStep<M extends BaseStepData, R> implements Bas
     protected abstract ParameterizedTypeReference<R> getResponseTypeReference();
 
     /**
-     * Executes this step with a given context
-     *
-     * @param context Provided context
-     * @return Result status object, null in case of failure.
-     * @throws Exception In case of any error.
-     */
-    @Override
-    public ResultStatusObject execute(Map<String, Object> context) throws Exception {
-        StepLogger stepLogger = stepLoggerFactory.createStepLogger();
-        stepLogger.start();
-        JSONObject jsonObject = execute(stepLogger, context);
-        stepLogger.close();
-        if (jsonObject == null) {
-            return null;
-        } else {
-            return ResultStatusObject.fromJsonObject(jsonObject);
-        }
-    }
-
-    /**
      * Execute this step with given logger and context objects.
      *
      * <p>Keeps backward compatibility with former approaches of step instantiation and execution</p>
@@ -155,7 +135,7 @@ public abstract class AbstractBaseStep<M extends BaseStepData, R> implements Bas
      * @return Result status object (with current activation status), null in case of failure.
      * @throws Exception In case of a failure.
      */
-    public final JSONObject execute(StepLogger stepLogger, Map<String, Object> context) throws Exception {
+    public final ResultStatusObject execute(StepLogger stepLogger, Map<String, Object> context) throws Exception {
         if (stepLogger == null) {
             stepLogger = DisabledStepLogger.INSTANCE;
         }
@@ -187,7 +167,12 @@ public abstract class AbstractBaseStep<M extends BaseStepData, R> implements Bas
             return null;
         }
 
-        return stepContext.getModel().getResultStatusObject();
+        final JSONObject resultStatusObject = stepContext.getModel().getResultStatusObject();
+        if (resultStatusObject == null) {
+            return null;
+        } else {
+            return ResultStatusObject.fromJsonObject(resultStatusObject);
+        }
     }
 
     /**
@@ -231,7 +216,6 @@ public abstract class AbstractBaseStep<M extends BaseStepData, R> implements Bas
      * @throws Exception when an error during encryption of the request data occurred
      */
     public void addEncryptedRequest(StepContext<M, R> stepContext, ClientEncryptor encryptor, byte[] data) throws Exception {
-        M model = stepContext.getModel();
         SimpleSecurityContext securityContext = (SimpleSecurityContext) stepContext.getSecurityContext();
         if (securityContext == null) {
             stepContext.setSecurityContext(

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/BaseStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/BaseStep.java
@@ -18,6 +18,7 @@ package io.getlime.security.powerauth.lib.cmd.steps;
 
 import io.getlime.security.powerauth.lib.cmd.consts.PowerAuthStep;
 import io.getlime.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import io.getlime.security.powerauth.lib.cmd.logging.StepLogger;
 import io.getlime.security.powerauth.lib.cmd.steps.pojo.ResultStatusObject;
 
 import java.util.List;
@@ -34,11 +35,12 @@ public interface BaseStep {
     /**
      * Execute this step with given context objects.
      *
+     * @param stepLogger Step logger.
      * @param context Context objects.
      * @return Result status object (with current activation status), null in case of failure.
      * @throws Exception In case of a failure.
      */
-    ResultStatusObject execute(Map<String, Object> context) throws Exception;
+    ResultStatusObject execute(StepLogger stepLogger, Map<String, Object> context) throws Exception;
 
     /**
      * @return Corresponding PowerAuth step

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/pojo/ResultStatusObject.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/pojo/ResultStatusObject.java
@@ -188,7 +188,10 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public SecretKey getSignatureBiometryKeyObject() {
-        String signatureBiometryKey = (String) jsonObject.get("signatureBiometryKey");
+        final String signatureBiometryKey = (String) jsonObject.get("signatureBiometryKey");
+        if (signatureBiometryKey == null) {
+            return null;
+        }
         return KEY_CONVERTOR.convertBytesToSharedSecretKey(Base64.getDecoder().decode(signatureBiometryKey));
     }
 
@@ -290,7 +293,10 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public SecretKey getSignaturePossessionKeyObject() {
-        String signaturePossessionKey = (String) jsonObject.get("signaturePossessionKey");
+        final String signaturePossessionKey = (String) jsonObject.get("signaturePossessionKey");
+        if (signaturePossessionKey == null) {
+            return null;
+        }
         return KEY_CONVERTOR.convertBytesToSharedSecretKey(Base64.getDecoder().decode(signaturePossessionKey));
     }
 
@@ -324,7 +330,10 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public SecretKey getTransportMasterKeyObject() {
-        String transportMasterKey = (String) jsonObject.get("transportMasterKey");
+        final String transportMasterKey = (String) jsonObject.get("transportMasterKey");
+        if (transportMasterKey == null) {
+            return null;
+        }
         return KEY_CONVERTOR.convertBytesToSharedSecretKey(Base64.getDecoder().decode(transportMasterKey));
     }
 

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/FileUtil.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/util/FileUtil.java
@@ -54,7 +54,7 @@ public class FileUtil {
                     "Empty " + fileDescription + " file",
                     "File not provided, assuming empty data.",
                     "WARNING",
-                    filePath
+                    null
             );
             return new byte[0];
         }

--- a/powerauth-java-cmd/src/main/java/io/getlime/security/powerauth/app/cmd/Application.java
+++ b/powerauth-java-cmd/src/main/java/io/getlime/security/powerauth/app/cmd/Application.java
@@ -289,12 +289,7 @@ public class Application {
 
                     stepExecutionService.execute(powerAuthStep, version, model);
                 }
-                case ACTIVATION_CREATE, ACTIVATION_PREPARE -> {
-                    if (powerAuthStep.equals(PowerAuthStep.ACTIVATION_PREPARE)) {
-                        System.err.println("The 'prepare' step name is deprecated, use the 'create' step name instead");
-                        powerAuthStep = PowerAuthStep.ACTIVATION_CREATE;
-                    }
-
+                case ACTIVATION_CREATE -> {
                     String customAttributesFileName = cmd.getOptionValue("C");
                     Map<String, Object> customAttributes =
                             FileUtil.readDataFromFile(stepLogger, customAttributesFileName, HashMap.class, "custom-attributes", "custom attributes");


### PR DESCRIPTION
The issue was caused by recreating the StepLogger instead of reusing the existing one. I cleaned up several minor topics related to the fix of the particular test case of #411.