### PR TITLE
Fix #444: Refactor BouncyCastle dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,6 @@
         <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <spring-boot.version>3.2.4</spring-boot.version>
-        <bc.version>1.78</bc.version>
         <commons-cli.version>1.6.0</commons-cli.version>
         <commons-io.version>2.16.1</commons-io.version>
         <json-simple.version>1.1.1</json-simple.version>
@@ -108,12 +107,6 @@
                 <groupId>io.getlime.security</groupId>
                 <artifactId>powerauth-java-cmd-lib</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk18on</artifactId>
-                <version>${bc.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/powerauth-java-cmd-lib/pom.xml
+++ b/powerauth-java-cmd-lib/pom.xml
@@ -56,12 +56,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
             <exclusions>

--- a/powerauth-java-cmd/pom.xml
+++ b/powerauth-java-cmd/pom.xml
@@ -50,10 +50,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>


### PR DESCRIPTION
Use transient dependency from `powerauth-crypto`

- [x] Depends on https://github.com/wultra/powerauth-crypto/pull/606