### PR TITLE
Fix #527: Validate hybrid signatures for JWT in temporary keys

### DIFF
--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/util/TemporaryKeyUtil.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/util/TemporaryKeyUtil.java
@@ -29,10 +29,12 @@ import com.wultra.core.rest.model.base.response.ObjectResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorScope;
 import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
+import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import com.wultra.security.powerauth.crypto.lib.util.SignatureUtils;
+import com.wultra.security.powerauth.crypto.lib.v4.PqcDsa;
 import com.wultra.security.powerauth.crypto.lib.v4.kdf.KeyFactory;
 import com.wultra.security.powerauth.crypto.lib.v4.model.SharedSecretClientContextEcdhe;
 import com.wultra.security.powerauth.crypto.lib.v4.model.SharedSecretClientContextHybrid;
@@ -60,19 +62,25 @@ import com.wultra.security.powerauth.lib.cmd.steps.model.v4.response.ResponseSha
 import com.wultra.security.powerauth.lib.cmd.steps.model.v4.response.ResponseSharedSecretHybrid;
 import com.wultra.security.powerauth.rest.api.model.request.TemporaryKeyRequest;
 import com.wultra.security.powerauth.rest.api.model.response.TemporaryKeyResponse;
+import lombok.Data;
 import org.bouncycastle.asn1.ASN1EncodableVector;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.DLSequence;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
+import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
 import java.security.PublicKey;
 import java.security.interfaces.ECPublicKey;
-import java.text.ParseException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -110,10 +118,13 @@ public class TemporaryKeyUtil {
     private static final KeyGenerator KEY_GENERATOR = new KeyGenerator();
     private static final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
     private static final SignatureUtils SIGNATURE_UTILS = new SignatureUtils();
+    private static final PqcDsa PQC_DSA = new PqcDsa();
 
     private static final SharedSecretEcdhe SHARED_SECRET_ECDHE = new SharedSecretEcdhe();
     private static final SharedSecretHybrid SHARED_SECRET_HYBRID = new SharedSecretHybrid();
     private static final ObjectMapper OBJECT_MAPPER = RestClientConfiguration.defaultMapper();
+
+    private static final JSONParser JSON_PARSER = new JSONParser();
 
     /**
      * Fetch temporary key for encryption from the server and store it into the step context.
@@ -258,31 +269,99 @@ public class TemporaryKeyUtil {
     private static void handleTemporaryKeyResponse(PowerAuthStep step, StepContext<? extends BaseStepData, ?> stepContext, ObjectResponse<TemporaryKeyResponse> response, EncryptorScope scope, SharedSecretAlgorithm algorithm) throws Exception {
         final BaseStepModel model = (BaseStepModel) stepContext.getModel();
         final String jwtResponse = response.getResponseObject().getJwt();
-        final SignedJWT decodedJWT = SignedJWT.parse(jwtResponse);
-        final PublicKey publicKey = switch (scope) {
-            case ACTIVATION_SCOPE -> (ECPublicKey) stepContext.getModel().getResultStatus().getEcServerPublicKeyObject();
-            case APPLICATION_SCOPE -> getEcMasterPublicKey(stepContext, algorithm);
-        };
-        if (!validateJwtSignature(decodedJWT, publicKey, algorithm)) {
-            stepContext.getStepLogger().writeError(step.id() + "-error-signature-invalid", "JWT signature is invalid");
-            return;
-        }
-        final String temporaryKeyId = (String) decodedJWT.getJWTClaimsSet().getClaim("sub");
-        stepContext.getAttributes().put(TEMPORARY_KEY_ID, temporaryKeyId);
+        final String temporaryKeyId;
         switch (model.getVersion().getMajorVersion()) {
-            case 3 -> handlePublicKeyResponse(stepContext, decodedJWT);
-            case 4 -> handleSharedSecretResponse(stepContext, decodedJWT, algorithm);
+            case 3 -> {
+                final PublicKey publicKey = switch (scope) {
+                    case ACTIVATION_SCOPE -> (ECPublicKey) stepContext.getModel().getResultStatus().getEcServerPublicKeyObject();
+                    case APPLICATION_SCOPE -> getEcMasterPublicKey(stepContext, algorithm);
+                };
+                final SignedJWT decodedJWT = SignedJWT.parse(jwtResponse);
+                handlePublicKeyResponse(stepContext, decodedJWT.getJWTClaimsSet());
+                if (!validateJwtSignature(decodedJWT, publicKey, algorithm)) {
+                    stepContext.getStepLogger().writeError(step.id() + "-error-signature-invalid", "JWT signature is invalid");
+                    return;
+                }
+                temporaryKeyId = (String) decodedJWT.getJWTClaimsSet().getClaim("sub");
+            }
+            case 4 -> {
+                final Map<String, JwtSignatureData> signatureData = extractSignatureData(jwtResponse);
+                if (signatureData.get("ES384") == null) {
+                    throw new IllegalStateException("Missing EC signature for algorithm: " + algorithm);
+                }
+                if (algorithm == SharedSecretAlgorithm.EC_P384_ML_L3 && signatureData.get("ML-DSA-65") == null) {
+                    throw new IllegalStateException("Missing ML-DSA signature for algorithm: " + algorithm);
+                }
+                final JWTClaimsSet claims = extractClaims(jwtResponse);
+                handleSharedSecretResponse(stepContext, claims, algorithm);
+                final Map<String, PublicKey> publicKeys = new HashMap<>();
+                switch (algorithm) {
+                    case EC_P384 -> {
+                        switch (scope) {
+                            case ACTIVATION_SCOPE -> publicKeys.put("ES384", stepContext.getModel().getResultStatus().getEcServerPublicKeyObject());
+                            case APPLICATION_SCOPE -> publicKeys.put("ES384", getEcMasterPublicKey(stepContext, algorithm));
+                        }
+                    }
+                    case EC_P384_ML_L3 -> {
+                        switch (scope) {
+                            case ACTIVATION_SCOPE -> {
+                                publicKeys.put("ES384", stepContext.getModel().getResultStatus().getEcServerPublicKeyObject());
+                                publicKeys.put("ML-DSA-65", stepContext.getModel().getResultStatus().getPqcServerPublicKeyObject());
+                            }
+                            case APPLICATION_SCOPE -> {
+                                publicKeys.put("ES384", getEcMasterPublicKey(stepContext, algorithm));
+                                publicKeys.put("ML-DSA-65", getMlDsaMasterPublicKey(stepContext));
+                            }
+                        }
+                    }
+                    default -> throw new IllegalStateException("Unsupported algorithm: " + algorithm);
+                }
+
+                if (!validateHybridSignatures(signatureData, publicKeys, algorithm)) {
+                    stepContext.getStepLogger().writeError(step.id() + "-error-signature-invalid", "JWT signature is invalid");
+                    return;
+                }
+                temporaryKeyId = claims.getStringClaim("sub");
+            }
             default -> throw new IllegalStateException("Unsupported version" + model.getVersion());
         }
+        stepContext.getAttributes().put(TEMPORARY_KEY_ID, temporaryKeyId);
     }
 
-    private static void handlePublicKeyResponse(StepContext<? extends BaseStepData, ?> stepContext, SignedJWT decodedJWT) throws ParseException {
-        final String temporaryPublicKey = (String) decodedJWT.getJWTClaimsSet().getClaim("publicKey");
+    private static Map<String, JwtSignatureData> extractSignatureData(String jwtJson) throws ParseException {
+        final JSONObject jwtObject = (JSONObject) JSON_PARSER.parse(jwtJson);
+        final JSONArray signatures = (JSONArray) jwtObject.get("signatures");
+        final String payloadB64 = (String) jwtObject.get("payload");
+        final Map<String, JwtSignatureData> result = new HashMap<>();
+        for (Object sigObj : signatures) {
+            final JSONObject sigEntry = (JSONObject) sigObj;
+            final String protectedB64 = (String) sigEntry.get("protected");
+            final String signatureB64 = (String) sigEntry.get("signature");
+            final String protectedJson = new String(Base64.getUrlDecoder().decode(protectedB64), StandardCharsets.UTF_8);
+            final JSONObject protectedHeader = (JSONObject) JSON_PARSER.parse(protectedJson);
+            final String alg = (String) protectedHeader.get("alg");
+            final String signingInput = protectedB64 + "." + payloadB64;
+            result.put(alg, new JwtSignatureData(signatureB64, signingInput));
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static JWTClaimsSet extractClaims(String jwtJson) throws java.text.ParseException, ParseException {
+        JSONObject jwtObject = (JSONObject) JSON_PARSER.parse(jwtJson);
+        String payloadBase64 = (String) jwtObject.get("payload");
+        String payloadJson = new String(Base64.getUrlDecoder().decode(payloadBase64), StandardCharsets.UTF_8);
+        final JSONObject payload = (JSONObject) JSON_PARSER.parse(payloadJson);
+        return JWTClaimsSet.parse(payload);
+    }
+
+    private static void handlePublicKeyResponse(StepContext<? extends BaseStepData, ?> stepContext, JWTClaimsSet claims) {
+        final String temporaryPublicKey = (String) claims.getClaim("publicKey");
         stepContext.getAttributes().put(TEMPORARY_PUBLIC_KEY, temporaryPublicKey);
     }
 
-    private static void handleSharedSecretResponse(StepContext<? extends BaseStepData, ?> stepContext, SignedJWT decodedJWT, SharedSecretAlgorithm algorithm) throws ParseException, GenericCryptoException {
-        final Object claim = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+    private static void handleSharedSecretResponse(StepContext<? extends BaseStepData, ?> stepContext, JWTClaimsSet claims, SharedSecretAlgorithm algorithm) throws GenericCryptoException {
+        final Object claim = claims.getClaim("sharedSecretResponse");
         final SecretKey sharedSecret = switch (algorithm) {
             case EC_P384 -> {
                 final ResponseSharedSecretEcdhe serverResponse = OBJECT_MAPPER.convertValue(claim, ResponseSharedSecretEcdhe.class);
@@ -305,20 +384,43 @@ public class TemporaryKeyUtil {
         stepContext.getAttributes().remove(TEMPORARY_CLIENT_CONTEXT);
     }
 
-    private static boolean validateJwtSignature(SignedJWT jwt, PublicKey publicKey, SharedSecretAlgorithm algorithm) throws Exception {
+    private static boolean validateHybridSignatures(Map<String, JwtSignatureData> signatureData, Map<String, PublicKey> publicKeys, SharedSecretAlgorithm algorithm) throws IOException, GenericCryptoException, InvalidKeyException, CryptoProviderException {
+        if (algorithm != SharedSecretAlgorithm.EC_P384 && algorithm != SharedSecretAlgorithm.EC_P384_ML_L3) {
+            return false;
+        }
+        final JwtSignatureData signatureEc = signatureData.get("ES384");
+        final byte[] signingInputEc = signatureEc.getSigningInput().getBytes(StandardCharsets.UTF_8);
+        final byte[] signatureEcBytes = convertRawSignatureToDER(Base64URL.from(signatureEc.getSignature()).decode());
+        final PublicKey publicKeyEc = publicKeys.get("ES384");
+        boolean signaturesValid = validateEcSignature(signingInputEc, signatureEcBytes, publicKeyEc, algorithm);
+        if (algorithm == SharedSecretAlgorithm.EC_P384_ML_L3) {
+            final PublicKey publicKeyMlDsa = publicKeys.get("ML-DSA-65");
+            final JwtSignatureData signatureMlDsa = signatureData.get("ML-DSA-65");
+            final byte[] signingInputMlDsa = signatureMlDsa.getSigningInput().getBytes(StandardCharsets.UTF_8);
+            final byte[] signatureMlDsaBytes = Base64URL.from(signatureMlDsa.getSignature()).decode();
+            signaturesValid = signaturesValid && PQC_DSA.verify(publicKeyMlDsa, signingInputMlDsa, signatureMlDsaBytes);
+        }
+        return signaturesValid;
+    }
+
+    private static boolean validateJwtSignature(SignedJWT jwt, PublicKey publicKey, SharedSecretAlgorithm algorithm) throws IOException, GenericCryptoException, InvalidKeyException, CryptoProviderException {
         final Base64URL[] jwtParts = jwt.getParsedParts();
         final Base64URL encodedHeader = jwtParts[0];
         final Base64URL encodedPayload = jwtParts[1];
         final Base64URL encodedSignature = jwtParts[2];
-        final String signingInput = encodedHeader + "." + encodedPayload;
+        final byte[] signingInput = (encodedHeader + "." + encodedPayload).getBytes(StandardCharsets.UTF_8);
         final byte[] signatureBytes = convertRawSignatureToDER(encodedSignature.decode());
+        return validateEcSignature(signingInput, signatureBytes, publicKey, algorithm);
+    }
+
+    private static boolean validateEcSignature(byte[] signingInput, byte[] signatureBytes, PublicKey publicKey, SharedSecretAlgorithm algorithm) throws GenericCryptoException, InvalidKeyException, CryptoProviderException {
         return switch (algorithm) {
-            case EC_P256 -> SIGNATURE_UTILS.validateECDSASignature(EcCurve.P256, signingInput.getBytes(StandardCharsets.UTF_8), signatureBytes, publicKey);
-            case EC_P384, EC_P384_ML_L3 -> SIGNATURE_UTILS.validateECDSASignature(EcCurve.P384, signingInput.getBytes(StandardCharsets.UTF_8), signatureBytes, publicKey);
+            case EC_P256 -> SIGNATURE_UTILS.validateECDSASignature(EcCurve.P256, signingInput, signatureBytes, publicKey);
+            case EC_P384, EC_P384_ML_L3 -> SIGNATURE_UTILS.validateECDSASignature(EcCurve.P384, signingInput, signatureBytes, publicKey);
         };
     }
 
-    private static byte[] convertRawSignatureToDER(byte[] rawSignature) throws Exception {
+    private static byte[] convertRawSignatureToDER(byte[] rawSignature) throws IOException {
         if (rawSignature.length % 2 != 0) {
             throw new IllegalArgumentException("Invalid ECDSA signature format");
         }
@@ -365,7 +467,24 @@ public class TemporaryKeyUtil {
                 case EC_P384, EC_P384_ML_L3 -> encryptionModel.getMasterPublicKeyP384();
             };
         }
-        throw new IllegalStateException("Invalid model for obtaining master public key");
+        throw new IllegalStateException("Invalid model for obtaining ECDSA master public key");
+    }
+
+    private static PublicKey getMlDsaMasterPublicKey(StepContext<? extends BaseStepData, ?> stepContext) {
+        if (stepContext.getModel() instanceof ActivationData activationModel) {
+            return activationModel.getMasterPublicKeyMlDsa65();
+        } else if (stepContext.getModel() instanceof EncryptStepModel encryptionModel) {
+            return encryptionModel.getMasterPublicKeyMlDsa65();
+        }
+        throw new IllegalStateException("Invalid model for obtaining ML-DSA master public key");
+    }
+
+    @Data
+    private static class JwtSignatureData {
+
+        public final String signature;
+        public final String signingInput;
+
     }
 
 }


### PR DESCRIPTION
Validation of ES384 and ML-DSA-65 signatures.